### PR TITLE
Optimize parser

### DIFF
--- a/lib/csgo_stats/events/accolade.ex
+++ b/lib/csgo_stats/events/accolade.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.Accolade do
-  defstruct [:award, :player, :value, :position, :score]
+  defstruct [:award, :player, :value, :position, :score, :timestamp]
 end

--- a/lib/csgo_stats/events/assisted.ex
+++ b/lib/csgo_stats/events/assisted.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.Assisted do
-  defstruct [:assistant, :killed]
+  defstruct [:assistant, :killed, :timestamp]
 end

--- a/lib/csgo_stats/events/attacked.ex
+++ b/lib/csgo_stats/events/attacked.ex
@@ -7,6 +7,7 @@ defmodule CsgoStats.Events.Attacked do
     :damage_armor,
     :health,
     :armor,
-    :hitgroup
+    :hitgroup,
+    :timestamp
   ]
 end

--- a/lib/csgo_stats/events/began_bomb_defuse.ex
+++ b/lib/csgo_stats/events/began_bomb_defuse.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.BeganBombDefuse do
-  defstruct [:player, :kit]
+  defstruct [:player, :kit, :timestamp]
 end

--- a/lib/csgo_stats/events/defused_the_bomb.ex
+++ b/lib/csgo_stats/events/defused_the_bomb.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.DefusedTheBomb do
-  defstruct [:player]
+  defstruct [:player, :timestamp]
 end

--- a/lib/csgo_stats/events/dropped_the_bomb.ex
+++ b/lib/csgo_stats/events/dropped_the_bomb.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.DroppedTheBomb do
-  defstruct [:player]
+  defstruct [:player, :timestamp]
 end

--- a/lib/csgo_stats/events/freeze_period_started.ex
+++ b/lib/csgo_stats/events/freeze_period_started.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.FreezePeriodStarted do
-  defstruct []
+  defstruct [:timestamp]
 end

--- a/lib/csgo_stats/events/game_commencing.ex
+++ b/lib/csgo_stats/events/game_commencing.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.GameCommencing do
-  defstruct []
+  defstruct [:timestamp]
 end

--- a/lib/csgo_stats/events/game_over.ex
+++ b/lib/csgo_stats/events/game_over.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.GameOver do
-  defstruct [:game_mode, :game_map, :ct_score, :t_score, :duration]
+  defstruct [:game_mode, :game_map, :ct_score, :t_score, :duration, :timestamp]
 end

--- a/lib/csgo_stats/events/got_the_bomb.ex
+++ b/lib/csgo_stats/events/got_the_bomb.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.GotTheBomb do
-  defstruct [:player]
+  defstruct [:player, :timestamp]
 end

--- a/lib/csgo_stats/events/killed.ex
+++ b/lib/csgo_stats/events/killed.ex
@@ -1,9 +1,3 @@
 defmodule CsgoStats.Events.Killed do
-  defstruct [
-    :killer,
-    :killed,
-    :weapon,
-    :headshot,
-    :penetrated
-  ]
+  defstruct [:killer, :killed, :weapon, :headshot, :penetrated, :timestamp]
 end

--- a/lib/csgo_stats/events/killed_by_the_bomb.ex
+++ b/lib/csgo_stats/events/killed_by_the_bomb.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.KilledByTheBomb do
-  defstruct [:player]
+  defstruct [:player, :timestamp]
 end

--- a/lib/csgo_stats/events/killed_other.ex
+++ b/lib/csgo_stats/events/killed_other.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.KilledOther do
-  defstruct [:killer, :killed, :weapon, :headshot, :penetrated]
+  defstruct [:killer, :killed, :weapon, :headshot, :penetrated, :timestamp]
 end

--- a/lib/csgo_stats/events/match_start.ex
+++ b/lib/csgo_stats/events/match_start.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.MatchStart do
-  defstruct [:map]
+  defstruct [:map, :timestamp]
 end

--- a/lib/csgo_stats/events/planted_the_bomb.ex
+++ b/lib/csgo_stats/events/planted_the_bomb.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.PlantedTheBomb do
-  defstruct [:player]
+  defstruct [:player, :timestamp]
 end

--- a/lib/csgo_stats/events/player_connected.ex
+++ b/lib/csgo_stats/events/player_connected.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.PlayerConnected do
-  defstruct [:player, :address]
+  defstruct [:player, :address, :timestamp]
 end

--- a/lib/csgo_stats/events/player_disconnected.ex
+++ b/lib/csgo_stats/events/player_disconnected.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.PlayerDisconnected do
-  defstruct [:player, :reason]
+  defstruct [:player, :reason, :timestamp]
 end

--- a/lib/csgo_stats/events/player_entered_the_game.ex
+++ b/lib/csgo_stats/events/player_entered_the_game.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.PlayerEnteredTheGame do
-  defstruct [:player]
+  defstruct [:player, :timestamp]
 end

--- a/lib/csgo_stats/events/player_switched_team.ex
+++ b/lib/csgo_stats/events/player_switched_team.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.PlayerSwitchedTeam do
-  defstruct [:player, :from, :to]
+  defstruct [:player, :from, :to, :timestamp]
 end

--- a/lib/csgo_stats/events/round_end.ex
+++ b/lib/csgo_stats/events/round_end.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.RoundEnd do
-  defstruct []
+  defstruct [:timestamp]
 end

--- a/lib/csgo_stats/events/round_start.ex
+++ b/lib/csgo_stats/events/round_start.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.RoundStart do
-  defstruct []
+  defstruct [:timestamp]
 end

--- a/lib/csgo_stats/events/team_won.ex
+++ b/lib/csgo_stats/events/team_won.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.TeamWon do
-  defstruct [:team, :win_condition, :ct_score, :terrorist_score]
+  defstruct [:team, :win_condition, :ct_score, :terrorist_score, :timestamp]
 end

--- a/lib/csgo_stats/events/terrorists_win.ex
+++ b/lib/csgo_stats/events/terrorists_win.ex
@@ -1,3 +1,3 @@
 defmodule CsgoStats.Events.TerroristsWin do
-  defstruct [:ct_score, :terrorist_score]
+  defstruct [:ct_score, :terrorist_score, :timestamp]
 end

--- a/lib/csgo_stats/logs.ex
+++ b/lib/csgo_stats/logs.ex
@@ -29,10 +29,7 @@ defmodule CsgoStats.Logs do
 
   defp do_parse(entry) do
     Enum.reduce(entry.lines, [], fn line, acc ->
-      # Cut date out of the log. Example: "12/12/2019 - 21:13:56.031 - "
-      event_text = String.slice(line, 28..-1)
-
-      case Parser.parse(event_text) do
+      case Parser.parse(line) do
         {:ok, %event_type{} = event} ->
           Logger.debug([
             "event_parsed||",
@@ -56,7 +53,7 @@ defmodule CsgoStats.Logs do
           [event | acc]
 
         {:error, _, unparsed} ->
-          Logger.error(["event_error||", event_text, "||", unparsed])
+          Logger.error(["event_error||", line, "||", unparsed])
           acc
       end
     end)

--- a/lib/csgo_stats/logs.ex
+++ b/lib/csgo_stats/logs.ex
@@ -28,34 +28,13 @@ defmodule CsgoStats.Logs do
   end
 
   defp do_parse(entry) do
-    Enum.reduce(entry.lines, [], fn line, acc ->
-      case Parser.parse(line) do
-        {:ok, %event_type{} = event} ->
-          Logger.debug([
-            "event_parsed||",
-            Atom.to_string(event_type),
-            "||",
-            event |> Map.from_struct() |> Jason.encode!()
-          ])
+    case Parser.parse(entry.lines) do
+      {:ok, events} ->
+        events
 
-          [event | acc]
-
-        {:ok, %event_type{} = event, leftovers} ->
-          Logger.warn([
-            "event_leftover||",
-            Atom.to_string(event_type),
-            "||",
-            event |> Map.from_struct() |> Jason.encode!(),
-            "||",
-            leftovers
-          ])
-
-          [event | acc]
-
-        {:error, _, unparsed} ->
-          Logger.error(["event_error||", line, "||", unparsed])
-          acc
-      end
-    end)
+      {:error, _, unparsed} ->
+        Logger.error(["event_error||", entry.lines, "||", unparsed])
+        []
+    end
   end
 end

--- a/lib/csgo_stats/logs/entry.ex
+++ b/lib/csgo_stats/logs/entry.ex
@@ -7,16 +7,10 @@ defmodule CsgoStats.Logs.Entry do
     case Enum.all?(@metadata_keys, fn key -> Map.has_key?(metadata, key) end) do
       true ->
         entry = struct(__MODULE__, metadata)
-        {:ok, %{entry | lines: lines(data)}}
+        {:ok, %{entry | lines: data}}
 
       false ->
         {:error, :invalid_metadata}
     end
-  end
-
-  defp lines(data) do
-    data
-    |> String.trim_trailing()
-    |> String.split("\n")
   end
 end

--- a/test/csgo_stats/logs/parser_test.exs
+++ b/test/csgo_stats/logs/parser_test.exs
@@ -8,32 +8,34 @@ defmodule CsgoStats.Logs.ParserTest do
 
   describe "World events" do
     test "Game commencing" do
-      line = "World triggered \"Game_Commencing\""
-      assert {:ok, %Events.GameCommencing{}} = Parser.parse(line)
+      line = "11/24/2019 - 21:43:39.781 - World triggered \"Game_Commencing\""
+      assert {:ok, %Events.GameCommencing{timestamp: ts}} = Parser.parse(line)
+      assert NaiveDateTime.compare(ts, ~N[2019-11-24 21:43:39.781]) == :eq
     end
 
     test "Match start" do
-      line = "World triggered \"Match_Start\" on \"de_inferno\""
+      line = "11/24/2019 - 21:43:39.781 - World triggered \"Match_Start\" on \"de_inferno\""
       assert {:ok, %Events.MatchStart{map: "de_inferno"}} = Parser.parse(line)
     end
 
     test "Round start" do
-      line = "World triggered \"Round_Start\""
+      line = "11/24/2019 - 21:43:39.781 - World triggered \"Round_Start\""
       assert {:ok, %Events.RoundStart{}} = Parser.parse(line)
     end
 
     test "Round end" do
-      line = "World triggered \"Round_End\""
+      line = "11/24/2019 - 21:43:39.781 - World triggered \"Round_End\""
       assert {:ok, %Events.RoundEnd{}} = Parser.parse(line)
     end
 
     test "Starting freeze period" do
-      line = "Starting Freeze period"
+      line = "11/24/2019 - 21:43:39.781 - Starting Freeze period"
       assert {:ok, %Events.FreezePeriodStarted{}} = Parser.parse(line)
     end
 
     test "Team won" do
-      line = "Team \"TERRORIST\" triggered \"SFUI_Notice_Terrorists_Win\" (CT \"0\") (T \"1\")"
+      line =
+        "11/24/2019 - 21:43:39.781 - Team \"TERRORIST\" triggered \"SFUI_Notice_Terrorists_Win\" (CT \"0\") (T \"1\")"
 
       assert {:ok,
               %Events.TeamWon{
@@ -45,7 +47,8 @@ defmodule CsgoStats.Logs.ParserTest do
     end
 
     test "Game over" do
-      line = "Game Over: casual mg_de_inferno de_inferno score 3:8 after 18 min"
+      line =
+        "11/24/2019 - 21:43:39.781 - Game Over: casual mg_de_inferno de_inferno score 3:8 after 18 min"
 
       assert {:ok,
               %Events.GameOver{
@@ -60,59 +63,65 @@ defmodule CsgoStats.Logs.ParserTest do
 
   describe "Player events" do
     test "Player connected" do
-      line = "\"Uri<13><BOT><>\" connected, address \"\""
+      line = "11/24/2019 - 21:43:39.781 - \"Uri<13><BOT><>\" connected, address \"\""
 
       assert {:ok, %Events.PlayerConnected{address: nil, player: %{username: "Uri"}}} =
                Parser.parse(line)
     end
 
     test "Player switched team" do
-      line = "\"Uri<13><BOT>\" switched from team <Unassigned> to <CT>"
+      line =
+        "11/24/2019 - 21:43:39.781 - \"Uri<13><BOT>\" switched from team <Unassigned> to <CT>"
 
       assert {:ok, %Events.PlayerSwitchedTeam{player: %{username: "Uri"}, from: nil, to: :ct}} =
                Parser.parse(line)
     end
 
     test "Player entered the game" do
-      line = "\"Uri<13><BOT><>\" entered the game"
+      line = "11/24/2019 - 21:43:39.781 - \"Uri<13><BOT><>\" entered the game"
       assert {:ok, %Events.PlayerEnteredTheGame{player: %{username: "Uri"}}} = Parser.parse(line)
     end
 
     test "Got the bomb" do
-      line = "\"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" triggered \"Got_The_Bomb\""
+      line =
+        "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" triggered \"Got_The_Bomb\""
+
       assert {:ok, %Events.GotTheBomb{player: %{username: "tbroedsgaard"}}} = Parser.parse(line)
     end
 
     test "Dropped the bomb" do
-      line = "\"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" triggered \"Dropped_The_Bomb\""
+      line =
+        "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" triggered \"Dropped_The_Bomb\""
 
       assert {:ok, %Events.DroppedTheBomb{player: %{username: "tbroedsgaard"}}} =
                Parser.parse(line)
     end
 
     test "Planted the bomb" do
-      line = "\"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" triggered \"Planted_The_Bomb\""
+      line =
+        "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" triggered \"Planted_The_Bomb\""
 
       assert {:ok, %Events.PlantedTheBomb{player: %{username: "tbroedsgaard"}}} =
                Parser.parse(line)
     end
 
     test "Began bomb defuse with kit" do
-      line = "\"Clarence<17><BOT><CT>\" triggered \"Begin_Bomb_Defuse_With_Kit\""
+      line =
+        "11/24/2019 - 21:43:39.781 - \"Clarence<17><BOT><CT>\" triggered \"Begin_Bomb_Defuse_With_Kit\""
 
       assert {:ok, %Events.BeganBombDefuse{player: %{username: "Clarence"}, kit: true}} =
                Parser.parse(line)
     end
 
     test "Defused the bomb" do
-      line = "\"Elmer<18><BOT><CT>\" triggered \"Defused_The_Bomb\""
+      line = "11/24/2019 - 21:43:39.781 - \"Elmer<18><BOT><CT>\" triggered \"Defused_The_Bomb\""
 
       assert {:ok, %Events.DefusedTheBomb{player: %{username: "Elmer"}}} = Parser.parse(line)
     end
 
     test "Attacked" do
       line =
-        "\"tbroedsgaard<12><STEAM_1:1:42376214><CT>\" [932 -550 88] attacked \"Niles<16><BOT><TERRORIST>\" [145 648 77] with \"hkp2000\" (damage \"61\") (damage_armor \"29\") (health \"39\") (armor \"70\") (hitgroup \"head\")"
+        "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><CT>\" [932 -550 88] attacked \"Niles<16><BOT><TERRORIST>\" [145 648 77] with \"hkp2000\" (damage \"61\") (damage_armor \"29\") (health \"39\") (armor \"70\") (hitgroup \"head\")"
 
       assert {:ok,
               %Events.Attacked{
@@ -135,7 +144,7 @@ defmodule CsgoStats.Logs.ParserTest do
               }} = Parser.parse(line)
 
       left_leg =
-        "\"Clarence<17><BOT><CT>\" [1936 -184 256] attacked \"Niles<16><BOT><TERRORIST>\" [1798 -366 256] with \"aug\" (damage \"12\") (damage_armor \"0\") (health \"88\") (armor \"100\") (hitgroup \"left leg\")"
+        "11/24/2019 - 21:43:39.781 - \"Clarence<17><BOT><CT>\" [1936 -184 256] attacked \"Niles<16><BOT><TERRORIST>\" [1798 -366 256] with \"aug\" (damage \"12\") (damage_armor \"0\") (health \"88\") (armor \"100\") (hitgroup \"left leg\")"
 
       assert {:ok,
               %Events.Attacked{
@@ -148,7 +157,7 @@ defmodule CsgoStats.Logs.ParserTest do
 
     test "Killed" do
       line =
-        "\"Niles<16><BOT><TERRORIST>\" [418 570 87] killed \"Elmer<18><BOT><CT>\" [944 538 152] with \"glock\""
+        "11/24/2019 - 21:43:39.781 - \"Niles<16><BOT><TERRORIST>\" [418 570 87] killed \"Elmer<18><BOT><CT>\" [944 538 152] with \"glock\""
 
       assert {:ok,
               %Events.Killed{
@@ -160,7 +169,7 @@ defmodule CsgoStats.Logs.ParserTest do
               }} = Parser.parse(line)
 
       knifed =
-        "\"Niles<16><BOT><TERRORIST>\" [632 585 91] killed \"Albert<23><BOT><CT>\" [600 555 154] with \"knife_t\""
+        "11/24/2019 - 21:43:39.781 - \"Niles<16><BOT><TERRORIST>\" [632 585 91] killed \"Albert<23><BOT><CT>\" [600 555 154] with \"knife_t\""
 
       assert {:ok,
               %Events.Killed{
@@ -172,7 +181,7 @@ defmodule CsgoStats.Logs.ParserTest do
               }} = Parser.parse(knifed)
 
       silencer =
-        "\"Niles<16><BOT><TERRORIST>\" [632 585 91] killed \"Albert<23><BOT><CT>\" [600 555 154] with \"usp_silencer\""
+        "11/24/2019 - 21:43:39.781 - \"Niles<16><BOT><TERRORIST>\" [632 585 91] killed \"Albert<23><BOT><CT>\" [600 555 154] with \"usp_silencer\""
 
       assert {:ok,
               %Events.Killed{
@@ -184,7 +193,7 @@ defmodule CsgoStats.Logs.ParserTest do
               }} = Parser.parse(silencer)
 
       headshot =
-        "\"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" [1873 314 160] killed \"Yanni<15><BOT><CT>\" [1841 283 206] with \"glock\" (headshot)"
+        "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" [1873 314 160] killed \"Yanni<15><BOT><CT>\" [1841 283 206] with \"glock\" (headshot)"
 
       assert {:ok,
               %Events.Killed{
@@ -196,7 +205,7 @@ defmodule CsgoStats.Logs.ParserTest do
               }} = Parser.parse(headshot)
 
       penetrated =
-        "\"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" [2150 407 160] killed \"Clarence<17><BOT><CT>\" [1879 628 224] with \"glock\" (penetrated)"
+        "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" [2150 407 160] killed \"Clarence<17><BOT><CT>\" [1879 628 224] with \"glock\" (penetrated)"
 
       assert {:ok,
               %Events.Killed{
@@ -209,13 +218,15 @@ defmodule CsgoStats.Logs.ParserTest do
     end
 
     test "Killed by the bomb" do
-      line = "\"Graham<14><BOT><TERRORIST>\" [1494 792 204] was killed by the bomb."
+      line =
+        "11/24/2019 - 21:43:39.781 - \"Graham<14><BOT><TERRORIST>\" [1494 792 204] was killed by the bomb."
+
       assert {:ok, %Events.KilledByTheBomb{player: %{username: "Graham"}}} = Parser.parse(line)
     end
 
     test "Killed other" do
       chicken =
-        "\"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" [849 2387 143] killed other \"chicken<159>\" [814 2555 138] with \"awp\""
+        "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" [849 2387 143] killed other \"chicken<159>\" [814 2555 138] with \"awp\""
 
       assert {:ok,
               %Events.KilledOther{
@@ -227,7 +238,7 @@ defmodule CsgoStats.Logs.ParserTest do
               }} = Parser.parse(chicken)
 
       chicken =
-        "\"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" [849 2387 143] killed other \"chicken<159>\" [814 2555 138] with \"awp\" (headshot)"
+        "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" [849 2387 143] killed other \"chicken<159>\" [814 2555 138] with \"awp\" (headshot)"
 
       assert {:ok,
               %Events.KilledOther{
@@ -239,7 +250,7 @@ defmodule CsgoStats.Logs.ParserTest do
               }} = Parser.parse(chicken)
 
       func_breakable =
-        "\"Yogi<49><BOT><CT>\" [-471 -139 6] killed other \"func_breakable<113>\" [973 -61 175] with \"mp7\" (penetrated)"
+        "11/24/2019 - 21:43:39.781 - \"Yogi<49><BOT><CT>\" [-471 -139 6] killed other \"func_breakable<113>\" [973 -61 175] with \"mp7\" (penetrated)"
 
       assert {:ok,
               %Events.KilledOther{
@@ -252,7 +263,8 @@ defmodule CsgoStats.Logs.ParserTest do
     end
 
     test "Assisted" do
-      line = "\"Elmer<18><BOT><CT>\" assisted killing \"Niles<16><BOT><TERRORIST>\""
+      line =
+        "11/24/2019 - 21:43:39.781 - \"Elmer<18><BOT><CT>\" assisted killing \"Niles<16><BOT><TERRORIST>\""
 
       assert {:ok,
               %Events.Assisted{assistant: %{username: "Elmer"}, killed: %{username: "Niles"}}} =
@@ -260,7 +272,8 @@ defmodule CsgoStats.Logs.ParserTest do
     end
 
     test "Accolade" do
-      line = "ACCOLADE, FINAL: {3k},	Neil<8>,	VALUE: 1.000000,	POS: 2,	SCORE: 20.000002"
+      line =
+        "11/24/2019 - 21:43:39.781 - ACCOLADE, FINAL: {3k},	Neil<8>,	VALUE: 1.000000,	POS: 2,	SCORE: 20.000002"
 
       assert {:ok,
               %Events.Accolade{
@@ -273,7 +286,7 @@ defmodule CsgoStats.Logs.ParserTest do
 
     test "Player disconnected" do
       line =
-        "\"tbroedsgaard<12><STEAM_1:1:42376214><Unassigned>\" disconnected (reason \"Disconnect\")"
+        "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><Unassigned>\" disconnected (reason \"Disconnect\")"
 
       assert {:ok,
               %Events.PlayerDisconnected{
@@ -282,7 +295,7 @@ defmodule CsgoStats.Logs.ParserTest do
               }} = Parser.parse(line)
 
       kicked_by_console =
-        "\"Fergus<20><BOT><TERRORIST>\" disconnected (reason \"Kicked by Console\")"
+        "11/24/2019 - 21:43:39.781 - \"Fergus<20><BOT><TERRORIST>\" disconnected (reason \"Kicked by Console\")"
 
       assert {:ok,
               %Events.PlayerDisconnected{

--- a/test/csgo_stats/logs/parser_test.exs
+++ b/test/csgo_stats/logs/parser_test.exs
@@ -9,28 +9,28 @@ defmodule CsgoStats.Logs.ParserTest do
   describe "World events" do
     test "Game commencing" do
       line = "11/24/2019 - 21:43:39.781 - World triggered \"Game_Commencing\""
-      assert {:ok, %Events.GameCommencing{timestamp: ts}} = Parser.parse(line)
+      assert {:ok, [%Events.GameCommencing{timestamp: ts}]} = Parser.parse(line)
       assert NaiveDateTime.compare(ts, ~N[2019-11-24 21:43:39.781]) == :eq
     end
 
     test "Match start" do
       line = "11/24/2019 - 21:43:39.781 - World triggered \"Match_Start\" on \"de_inferno\""
-      assert {:ok, %Events.MatchStart{map: "de_inferno"}} = Parser.parse(line)
+      assert {:ok, [%Events.MatchStart{map: "de_inferno"}]} = Parser.parse(line)
     end
 
     test "Round start" do
       line = "11/24/2019 - 21:43:39.781 - World triggered \"Round_Start\""
-      assert {:ok, %Events.RoundStart{}} = Parser.parse(line)
+      assert {:ok, [%Events.RoundStart{}]} = Parser.parse(line)
     end
 
     test "Round end" do
       line = "11/24/2019 - 21:43:39.781 - World triggered \"Round_End\""
-      assert {:ok, %Events.RoundEnd{}} = Parser.parse(line)
+      assert {:ok, [%Events.RoundEnd{}]} = Parser.parse(line)
     end
 
     test "Starting freeze period" do
       line = "11/24/2019 - 21:43:39.781 - Starting Freeze period"
-      assert {:ok, %Events.FreezePeriodStarted{}} = Parser.parse(line)
+      assert {:ok, [%Events.FreezePeriodStarted{}]} = Parser.parse(line)
     end
 
     test "Team won" do
@@ -38,12 +38,14 @@ defmodule CsgoStats.Logs.ParserTest do
         "11/24/2019 - 21:43:39.781 - Team \"TERRORIST\" triggered \"SFUI_Notice_Terrorists_Win\" (CT \"0\") (T \"1\")"
 
       assert {:ok,
-              %Events.TeamWon{
-                team: :terrorist,
-                win_condition: :terrorists_win,
-                ct_score: 0,
-                terrorist_score: 1
-              }} = Parser.parse(line)
+              [
+                %Events.TeamWon{
+                  team: :terrorist,
+                  win_condition: :terrorists_win,
+                  ct_score: 0,
+                  terrorist_score: 1
+                }
+              ]} = Parser.parse(line)
     end
 
     test "Game over" do
@@ -51,13 +53,15 @@ defmodule CsgoStats.Logs.ParserTest do
         "11/24/2019 - 21:43:39.781 - Game Over: casual mg_de_inferno de_inferno score 3:8 after 18 min"
 
       assert {:ok,
-              %Events.GameOver{
-                game_mode: "casual",
-                game_map: "de_inferno",
-                ct_score: 3,
-                t_score: 8,
-                duration: 18
-              }} = Parser.parse(line)
+              [
+                %Events.GameOver{
+                  game_mode: "casual",
+                  game_map: "de_inferno",
+                  ct_score: 3,
+                  t_score: 8,
+                  duration: 18
+                }
+              ]} = Parser.parse(line)
     end
   end
 
@@ -65,7 +69,7 @@ defmodule CsgoStats.Logs.ParserTest do
     test "Player connected" do
       line = "11/24/2019 - 21:43:39.781 - \"Uri<13><BOT><>\" connected, address \"\""
 
-      assert {:ok, %Events.PlayerConnected{address: nil, player: %{username: "Uri"}}} =
+      assert {:ok, [%Events.PlayerConnected{address: nil, player: %{username: "Uri"}}]} =
                Parser.parse(line)
     end
 
@@ -73,27 +77,29 @@ defmodule CsgoStats.Logs.ParserTest do
       line =
         "11/24/2019 - 21:43:39.781 - \"Uri<13><BOT>\" switched from team <Unassigned> to <CT>"
 
-      assert {:ok, %Events.PlayerSwitchedTeam{player: %{username: "Uri"}, from: nil, to: :ct}} =
+      assert {:ok, [%Events.PlayerSwitchedTeam{player: %{username: "Uri"}, from: nil, to: :ct}]} =
                Parser.parse(line)
     end
 
     test "Player entered the game" do
       line = "11/24/2019 - 21:43:39.781 - \"Uri<13><BOT><>\" entered the game"
-      assert {:ok, %Events.PlayerEnteredTheGame{player: %{username: "Uri"}}} = Parser.parse(line)
+
+      assert {:ok, [%Events.PlayerEnteredTheGame{player: %{username: "Uri"}}]} =
+               Parser.parse(line)
     end
 
     test "Got the bomb" do
       line =
         "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" triggered \"Got_The_Bomb\""
 
-      assert {:ok, %Events.GotTheBomb{player: %{username: "tbroedsgaard"}}} = Parser.parse(line)
+      assert {:ok, [%Events.GotTheBomb{player: %{username: "tbroedsgaard"}}]} = Parser.parse(line)
     end
 
     test "Dropped the bomb" do
       line =
         "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" triggered \"Dropped_The_Bomb\""
 
-      assert {:ok, %Events.DroppedTheBomb{player: %{username: "tbroedsgaard"}}} =
+      assert {:ok, [%Events.DroppedTheBomb{player: %{username: "tbroedsgaard"}}]} =
                Parser.parse(line)
     end
 
@@ -101,7 +107,7 @@ defmodule CsgoStats.Logs.ParserTest do
       line =
         "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" triggered \"Planted_The_Bomb\""
 
-      assert {:ok, %Events.PlantedTheBomb{player: %{username: "tbroedsgaard"}}} =
+      assert {:ok, [%Events.PlantedTheBomb{player: %{username: "tbroedsgaard"}}]} =
                Parser.parse(line)
     end
 
@@ -109,14 +115,14 @@ defmodule CsgoStats.Logs.ParserTest do
       line =
         "11/24/2019 - 21:43:39.781 - \"Clarence<17><BOT><CT>\" triggered \"Begin_Bomb_Defuse_With_Kit\""
 
-      assert {:ok, %Events.BeganBombDefuse{player: %{username: "Clarence"}, kit: true}} =
+      assert {:ok, [%Events.BeganBombDefuse{player: %{username: "Clarence"}, kit: true}]} =
                Parser.parse(line)
     end
 
     test "Defused the bomb" do
       line = "11/24/2019 - 21:43:39.781 - \"Elmer<18><BOT><CT>\" triggered \"Defused_The_Bomb\""
 
-      assert {:ok, %Events.DefusedTheBomb{player: %{username: "Elmer"}}} = Parser.parse(line)
+      assert {:ok, [%Events.DefusedTheBomb{player: %{username: "Elmer"}}]} = Parser.parse(line)
     end
 
     test "Attacked" do
@@ -124,35 +130,39 @@ defmodule CsgoStats.Logs.ParserTest do
         "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><CT>\" [932 -550 88] attacked \"Niles<16><BOT><TERRORIST>\" [145 648 77] with \"hkp2000\" (damage \"61\") (damage_armor \"29\") (health \"39\") (armor \"70\") (hitgroup \"head\")"
 
       assert {:ok,
-              %Events.Attacked{
-                attacker: %{
-                  username: "tbroedsgaard",
-                  steam_id: "STEAM_1:1:42376214",
-                  team: :ct
-                },
-                attacked: %{
-                  username: "Niles",
-                  steam_id: "BOT",
-                  team: :terrorist
-                },
-                weapon: "hkp2000",
-                damage: 61,
-                damage_armor: 29,
-                health: 39,
-                armor: 70,
-                hitgroup: "head"
-              }} = Parser.parse(line)
+              [
+                %Events.Attacked{
+                  attacker: %{
+                    username: "tbroedsgaard",
+                    steam_id: "STEAM_1:1:42376214",
+                    team: :ct
+                  },
+                  attacked: %{
+                    username: "Niles",
+                    steam_id: "BOT",
+                    team: :terrorist
+                  },
+                  weapon: "hkp2000",
+                  damage: 61,
+                  damage_armor: 29,
+                  health: 39,
+                  armor: 70,
+                  hitgroup: "head"
+                }
+              ]} = Parser.parse(line)
 
       left_leg =
         "11/24/2019 - 21:43:39.781 - \"Clarence<17><BOT><CT>\" [1936 -184 256] attacked \"Niles<16><BOT><TERRORIST>\" [1798 -366 256] with \"aug\" (damage \"12\") (damage_armor \"0\") (health \"88\") (armor \"100\") (hitgroup \"left leg\")"
 
       assert {:ok,
-              %Events.Attacked{
-                attacker: %{username: "Clarence"},
-                attacked: %{username: "Niles"},
-                weapon: "aug",
-                hitgroup: "left leg"
-              }} = Parser.parse(left_leg)
+              [
+                %Events.Attacked{
+                  attacker: %{username: "Clarence"},
+                  attacked: %{username: "Niles"},
+                  weapon: "aug",
+                  hitgroup: "left leg"
+                }
+              ]} = Parser.parse(left_leg)
     end
 
     test "Killed" do
@@ -160,68 +170,78 @@ defmodule CsgoStats.Logs.ParserTest do
         "11/24/2019 - 21:43:39.781 - \"Niles<16><BOT><TERRORIST>\" [418 570 87] killed \"Elmer<18><BOT><CT>\" [944 538 152] with \"glock\""
 
       assert {:ok,
-              %Events.Killed{
-                killer: %{username: "Niles"},
-                killed: %{username: "Elmer"},
-                weapon: "glock",
-                headshot: false,
-                penetrated: false
-              }} = Parser.parse(line)
+              [
+                %Events.Killed{
+                  killer: %{username: "Niles"},
+                  killed: %{username: "Elmer"},
+                  weapon: "glock",
+                  headshot: false,
+                  penetrated: false
+                }
+              ]} = Parser.parse(line)
 
       knifed =
         "11/24/2019 - 21:43:39.781 - \"Niles<16><BOT><TERRORIST>\" [632 585 91] killed \"Albert<23><BOT><CT>\" [600 555 154] with \"knife_t\""
 
       assert {:ok,
-              %Events.Killed{
-                killer: %{username: "Niles"},
-                killed: %{username: "Albert"},
-                weapon: "knife_t",
-                headshot: false,
-                penetrated: false
-              }} = Parser.parse(knifed)
+              [
+                %Events.Killed{
+                  killer: %{username: "Niles"},
+                  killed: %{username: "Albert"},
+                  weapon: "knife_t",
+                  headshot: false,
+                  penetrated: false
+                }
+              ]} = Parser.parse(knifed)
 
       silencer =
         "11/24/2019 - 21:43:39.781 - \"Niles<16><BOT><TERRORIST>\" [632 585 91] killed \"Albert<23><BOT><CT>\" [600 555 154] with \"usp_silencer\""
 
       assert {:ok,
-              %Events.Killed{
-                killer: %{username: "Niles"},
-                killed: %{username: "Albert"},
-                weapon: "usp_silencer",
-                headshot: false,
-                penetrated: false
-              }} = Parser.parse(silencer)
+              [
+                %Events.Killed{
+                  killer: %{username: "Niles"},
+                  killed: %{username: "Albert"},
+                  weapon: "usp_silencer",
+                  headshot: false,
+                  penetrated: false
+                }
+              ]} = Parser.parse(silencer)
 
       headshot =
         "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" [1873 314 160] killed \"Yanni<15><BOT><CT>\" [1841 283 206] with \"glock\" (headshot)"
 
       assert {:ok,
-              %Events.Killed{
-                killer: %{username: "tbroedsgaard"},
-                killed: %{username: "Yanni"},
-                weapon: "glock",
-                headshot: true,
-                penetrated: false
-              }} = Parser.parse(headshot)
+              [
+                %Events.Killed{
+                  killer: %{username: "tbroedsgaard"},
+                  killed: %{username: "Yanni"},
+                  weapon: "glock",
+                  headshot: true,
+                  penetrated: false
+                }
+              ]} = Parser.parse(headshot)
 
       penetrated =
         "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" [2150 407 160] killed \"Clarence<17><BOT><CT>\" [1879 628 224] with \"glock\" (penetrated)"
 
       assert {:ok,
-              %Events.Killed{
-                killer: %{username: "tbroedsgaard"},
-                killed: %{username: "Clarence"},
-                weapon: "glock",
-                headshot: false,
-                penetrated: true
-              }} = Parser.parse(penetrated)
+              [
+                %Events.Killed{
+                  killer: %{username: "tbroedsgaard"},
+                  killed: %{username: "Clarence"},
+                  weapon: "glock",
+                  headshot: false,
+                  penetrated: true
+                }
+              ]} = Parser.parse(penetrated)
     end
 
     test "Killed by the bomb" do
       line =
         "11/24/2019 - 21:43:39.781 - \"Graham<14><BOT><TERRORIST>\" [1494 792 204] was killed by the bomb."
 
-      assert {:ok, %Events.KilledByTheBomb{player: %{username: "Graham"}}} = Parser.parse(line)
+      assert {:ok, [%Events.KilledByTheBomb{player: %{username: "Graham"}}]} = Parser.parse(line)
     end
 
     test "Killed other" do
@@ -229,37 +249,43 @@ defmodule CsgoStats.Logs.ParserTest do
         "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" [849 2387 143] killed other \"chicken<159>\" [814 2555 138] with \"awp\""
 
       assert {:ok,
-              %Events.KilledOther{
-                killer: %{username: "tbroedsgaard"},
-                killed: "chicken",
-                weapon: "awp",
-                penetrated: false,
-                headshot: false
-              }} = Parser.parse(chicken)
+              [
+                %Events.KilledOther{
+                  killer: %{username: "tbroedsgaard"},
+                  killed: "chicken",
+                  weapon: "awp",
+                  penetrated: false,
+                  headshot: false
+                }
+              ]} = Parser.parse(chicken)
 
       chicken =
         "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>\" [849 2387 143] killed other \"chicken<159>\" [814 2555 138] with \"awp\" (headshot)"
 
       assert {:ok,
-              %Events.KilledOther{
-                killer: %{username: "tbroedsgaard"},
-                killed: "chicken",
-                weapon: "awp",
-                penetrated: false,
-                headshot: true
-              }} = Parser.parse(chicken)
+              [
+                %Events.KilledOther{
+                  killer: %{username: "tbroedsgaard"},
+                  killed: "chicken",
+                  weapon: "awp",
+                  penetrated: false,
+                  headshot: true
+                }
+              ]} = Parser.parse(chicken)
 
       func_breakable =
         "11/24/2019 - 21:43:39.781 - \"Yogi<49><BOT><CT>\" [-471 -139 6] killed other \"func_breakable<113>\" [973 -61 175] with \"mp7\" (penetrated)"
 
       assert {:ok,
-              %Events.KilledOther{
-                killer: %{username: "Yogi"},
-                killed: "func_breakable",
-                weapon: "mp7",
-                penetrated: true,
-                headshot: false
-              }} = Parser.parse(func_breakable)
+              [
+                %Events.KilledOther{
+                  killer: %{username: "Yogi"},
+                  killed: "func_breakable",
+                  weapon: "mp7",
+                  penetrated: true,
+                  headshot: false
+                }
+              ]} = Parser.parse(func_breakable)
     end
 
     test "Assisted" do
@@ -267,7 +293,7 @@ defmodule CsgoStats.Logs.ParserTest do
         "11/24/2019 - 21:43:39.781 - \"Elmer<18><BOT><CT>\" assisted killing \"Niles<16><BOT><TERRORIST>\""
 
       assert {:ok,
-              %Events.Assisted{assistant: %{username: "Elmer"}, killed: %{username: "Niles"}}} =
+              [%Events.Assisted{assistant: %{username: "Elmer"}, killed: %{username: "Niles"}}]} =
                Parser.parse(line)
     end
 
@@ -276,12 +302,14 @@ defmodule CsgoStats.Logs.ParserTest do
         "11/24/2019 - 21:43:39.781 - ACCOLADE, FINAL: {3k},	Neil<8>,	VALUE: 1.000000,	POS: 2,	SCORE: 20.000002"
 
       assert {:ok,
-              %Events.Accolade{
-                player: %{username: "Neil"},
-                award: "3k",
-                value: 1.0,
-                score: 20.000002
-              }} = Parser.parse(line)
+              [
+                %Events.Accolade{
+                  player: %{username: "Neil"},
+                  award: "3k",
+                  value: 1.0,
+                  score: 20.000002
+                }
+              ]} = Parser.parse(line)
     end
 
     test "Player disconnected" do
@@ -289,19 +317,53 @@ defmodule CsgoStats.Logs.ParserTest do
         "11/24/2019 - 21:43:39.781 - \"tbroedsgaard<12><STEAM_1:1:42376214><Unassigned>\" disconnected (reason \"Disconnect\")"
 
       assert {:ok,
-              %Events.PlayerDisconnected{
-                player: %{username: "tbroedsgaard"},
-                reason: "Disconnect"
-              }} = Parser.parse(line)
+              [
+                %Events.PlayerDisconnected{
+                  player: %{username: "tbroedsgaard"},
+                  reason: "Disconnect"
+                }
+              ]} = Parser.parse(line)
 
       kicked_by_console =
         "11/24/2019 - 21:43:39.781 - \"Fergus<20><BOT><TERRORIST>\" disconnected (reason \"Kicked by Console\")"
 
       assert {:ok,
-              %Events.PlayerDisconnected{
-                player: %{username: "Fergus"},
-                reason: "Kicked by Console"
-              }} = Parser.parse(kicked_by_console)
+              [
+                %Events.PlayerDisconnected{
+                  player: %{username: "Fergus"},
+                  reason: "Kicked by Console"
+                }
+              ]} = Parser.parse(kicked_by_console)
+    end
+  end
+
+  describe "multi-line parsing" do
+    test "parses one event per line" do
+      lines =
+        "11/24/2019 - 21:43:39.781 - World triggered \"Game_Commencing\"\n11/24/2019 - 21:43:39.781 - World triggered \"Match_Start\" on \"de_inferno\"\n"
+
+      assert {:ok, [%Events.GameCommencing{}, %Events.MatchStart{}]} = Parser.parse(lines)
+    end
+
+    test "skips unhandled events at the beginning" do
+      lines =
+        "11/24/2019 - 21:43:02.156 - Unhandled event\n11/24/2019 - 21:43:39.781 - World triggered \"Game_Commencing\"\n11/24/2019 - 21:43:39.781 - World triggered \"Match_Start\" on \"de_inferno\"\n"
+
+      assert {:ok, [%Events.GameCommencing{}, %Events.MatchStart{}]} = Parser.parse(lines)
+    end
+
+    test "skips unhandled events in the middle" do
+      lines =
+        "11/24/2019 - 21:43:39.781 - World triggered \"Game_Commencing\"\n11/24/2019 - 21:43:02.156 - Unhandled event\n11/24/2019 - 21:43:39.781 - World triggered \"Match_Start\" on \"de_inferno\"\n"
+
+      assert {:ok, [%Events.GameCommencing{}, %Events.MatchStart{}]} = Parser.parse(lines)
+    end
+
+    test "skips unhandled events at the end" do
+      lines =
+        "11/24/2019 - 21:43:39.781 - World triggered \"Game_Commencing\"\n11/24/2019 - 21:43:39.781 - World triggered \"Match_Start\" on \"de_inferno\"\n11/24/2019 - 21:43:02.156 - Unhandled event\n"
+
+      assert {:ok, [%Events.GameCommencing{}, %Events.MatchStart{}]} = Parser.parse(lines)
     end
   end
 end


### PR DESCRIPTION
This PR optimizes the parser in two ways:

1. Enable parsing of multiple loglines in a single pass, instead of having to first split the loglines at newlines.
2. Reduce repetitions in parser definitions (e.g.  `player` was the first entry in many parser definitions) in order to avoid parsing the same element multiple times.

In addition, the PR also adds parsing of timestamp per event (as the `x-timestamp` header sent with an HTTP  request can be quite different from the actual event time). 