### PR TITLE
Handle equipment events

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -209,7 +209,8 @@ body {
                     text-align: left;
                 }
 
-                &:nth-of-type(2) {
+                &:nth-of-type(2),
+                &:nth-of-type(3) {
                     flex-basis: 120px;
                 }
 

--- a/lib/csgo_stats/events/dropped.ex
+++ b/lib/csgo_stats/events/dropped.ex
@@ -1,0 +1,3 @@
+defmodule CsgoStats.Events.Dropped do
+  defstruct [:player, :item, :timestamp]
+end

--- a/lib/csgo_stats/events/left_buyzone.ex
+++ b/lib/csgo_stats/events/left_buyzone.ex
@@ -1,0 +1,3 @@
+defmodule CsgoStats.Events.LeftBuyzone do
+  defstruct [:player, :c4, :defuser, :helmet, :kevlar, :weapons, :timestamp]
+end

--- a/lib/csgo_stats/events/picked_up.ex
+++ b/lib/csgo_stats/events/picked_up.ex
@@ -1,0 +1,3 @@
+defmodule CsgoStats.Events.PickedUp do
+  defstruct [:player, :item, :timestamp]
+end

--- a/lib/csgo_stats/events/purchased.ex
+++ b/lib/csgo_stats/events/purchased.ex
@@ -1,0 +1,3 @@
+defmodule CsgoStats.Events.Purchased do
+  defstruct [:player, :item, :timestamp]
+end

--- a/lib/csgo_stats/logs/parser.ex
+++ b/lib/csgo_stats/logs/parser.ex
@@ -77,7 +77,8 @@ defmodule CsgoStats.Logs.Parser do
       Parser.KilledOther.parser(),
       Parser.MoneyChange.parser(),
       Parser.LeftBuyzone.parser(),
-      Parser.PickedUp.parser()
+      Parser.PickedUp.parser(),
+      Parser.Dropped.parser()
     ])
     |> reduce({:set_player, []})
 

--- a/lib/csgo_stats/logs/parser.ex
+++ b/lib/csgo_stats/logs/parser.ex
@@ -78,7 +78,8 @@ defmodule CsgoStats.Logs.Parser do
       Parser.MoneyChange.parser(),
       Parser.LeftBuyzone.parser(),
       Parser.PickedUp.parser(),
-      Parser.Dropped.parser()
+      Parser.Dropped.parser(),
+      Parser.Purchased.parser()
     ])
     |> reduce({:set_player, []})
 

--- a/lib/csgo_stats/logs/parser.ex
+++ b/lib/csgo_stats/logs/parser.ex
@@ -75,7 +75,8 @@ defmodule CsgoStats.Logs.Parser do
       Parser.Killed.parser(),
       Parser.Assisted.parser(),
       Parser.KilledOther.parser(),
-      Parser.MoneyChange.parser()
+      Parser.MoneyChange.parser(),
+      Parser.LeftBuyzone.parser()
     ])
     |> reduce({:set_player, []})
 

--- a/lib/csgo_stats/logs/parser.ex
+++ b/lib/csgo_stats/logs/parser.ex
@@ -76,7 +76,8 @@ defmodule CsgoStats.Logs.Parser do
       Parser.Assisted.parser(),
       Parser.KilledOther.parser(),
       Parser.MoneyChange.parser(),
-      Parser.LeftBuyzone.parser()
+      Parser.LeftBuyzone.parser(),
+      Parser.PickedUp.parser()
     ])
     |> reduce({:set_player, []})
 

--- a/lib/csgo_stats/logs/parser/dropped.ex
+++ b/lib/csgo_stats/logs/parser/dropped.ex
@@ -1,0 +1,39 @@
+defmodule CsgoStats.Logs.Parser.Dropped do
+  import NimbleParsec
+
+  alias CsgoStats.Events
+  alias CsgoStats.Logs.Parser
+
+  # Example: "Wesley<16><BOT><TERRORIST>" dropped "glock"
+  def parser() do
+    ignore(string(" dropped "))
+    |> choice([
+      Parser.Weapon.parser(),
+      item()
+    ])
+    |> reduce({__MODULE__, :cast, []})
+  end
+
+  defp item() do
+    ignore(string(~s/"/))
+    |> choice([
+      string("defuser"),
+      string("vesthelm"),
+      string("vest")
+    ])
+    |> ignore(string(~s/"/))
+    |> reduce({__MODULE__, :cast_item, []})
+  end
+
+  def cast_item([item]) do
+    case item do
+      "defuser" -> :defuser
+      "vesthelm" -> :vesthelm
+      "vest" -> :vest
+    end
+  end
+
+  def cast([item]) do
+    %Events.Dropped{item: item}
+  end
+end

--- a/lib/csgo_stats/logs/parser/left_buyzone.ex
+++ b/lib/csgo_stats/logs/parser/left_buyzone.ex
@@ -47,6 +47,8 @@ defmodule CsgoStats.Logs.Parser.LeftBuyzone do
       items,
       %Events.LeftBuyzone{weapons: [], defuser: false, c4: false, helmet: false, kevlar: 0},
       fn
+        # Skip {:weapon, :c4} as these buyzone events also contain "C4"
+        {:weapon, :c4}, acc -> acc
         {:weapon, weapon}, acc -> %{acc | weapons: acc.weapons ++ [weapon]}
         {:kevlar, hitpoints}, acc -> %{acc | kevlar: hitpoints}
         "C4", acc -> %{acc | c4: true}

--- a/lib/csgo_stats/logs/parser/left_buyzone.ex
+++ b/lib/csgo_stats/logs/parser/left_buyzone.ex
@@ -1,0 +1,70 @@
+defmodule CsgoStats.Logs.Parser.LeftBuyzone do
+  import NimbleParsec
+
+  alias CsgoStats.Events
+  alias CsgoStats.Logs.Parser
+
+  # Example: "Fred<27><BOT><CT>" left buyzone with [ weapon_knife weapon_hkp2000 weapon_scar20 weapon_hegrenade ]
+  def parser() do
+    ignore(string(" left buyzone with [ "))
+    |> concat(items())
+    |> ignore(string("]"))
+    |> reduce({__MODULE__, :cast, []})
+  end
+
+  defp items() do
+    item()
+    |> ignore(string(" "))
+    |> repeat()
+  end
+
+  # unhandled
+  # C4
+  # defuser
+  # helmet
+  defp item() do
+    choice([
+      weapon(),
+      kevlar(),
+      string("C4"),
+      string("defuser"),
+      string("helmet")
+    ])
+  end
+
+  defp weapon() do
+    ignore(string("weapon_"))
+    |> concat(Parser.Weapon.weapon_name())
+    |> reduce({__MODULE__, :cast_weapon, []})
+  end
+
+  defp kevlar() do
+    ignore(string("kevlar"))
+    |> ignore(string("("))
+    |> integer(min: 1)
+    |> ignore(string(")"))
+    |> reduce({__MODULE__, :cast_kevlar, []})
+  end
+
+  def cast(items) do
+    Enum.reduce(
+      items,
+      %Events.LeftBuyzone{weapons: [], defuser: false, c4: false, helmet: false, kevlar: 0},
+      fn
+        {:weapon, weapon}, acc -> %{acc | weapons: acc.weapons ++ [weapon]}
+        {:kevlar, hitpoints}, acc -> %{acc | kevlar: hitpoints}
+        "C4", acc -> %{acc | c4: true}
+        "defuser", acc -> %{acc | defuser: true}
+        "helmet", acc -> %{acc | helmet: true}
+      end
+    )
+  end
+
+  def cast_weapon([weapon]) do
+    {:weapon, weapon}
+  end
+
+  def cast_kevlar([hitpoints]) do
+    {:kevlar, hitpoints}
+  end
+end

--- a/lib/csgo_stats/logs/parser/left_buyzone.ex
+++ b/lib/csgo_stats/logs/parser/left_buyzone.ex
@@ -18,10 +18,6 @@ defmodule CsgoStats.Logs.Parser.LeftBuyzone do
     |> repeat()
   end
 
-  # unhandled
-  # C4
-  # defuser
-  # helmet
   defp item() do
     choice([
       weapon(),

--- a/lib/csgo_stats/logs/parser/picked_up.ex
+++ b/lib/csgo_stats/logs/parser/picked_up.ex
@@ -1,0 +1,29 @@
+defmodule CsgoStats.Logs.Parser.PickedUp do
+  import NimbleParsec
+
+  alias CsgoStats.Events
+  alias CsgoStats.Logs.Parser
+
+  # Example: "George<21><BOT><CT>" picked up "hkp2000"
+  def parser() do
+    ignore(string(" picked up "))
+    |> choice([
+      Parser.Weapon.parser(),
+      defuser()
+    ])
+    |> reduce({__MODULE__, :cast, []})
+  end
+
+  defp defuser() do
+    ignore(string(~s/"defuser"/))
+    |> reduce({__MODULE__, :cast_defuser, []})
+  end
+
+  def cast_defuser([]) do
+    :defuser
+  end
+
+  def cast([item]) do
+    %Events.PickedUp{item: item}
+  end
+end

--- a/lib/csgo_stats/logs/parser/purchased.ex
+++ b/lib/csgo_stats/logs/parser/purchased.ex
@@ -1,0 +1,42 @@
+defmodule CsgoStats.Logs.Parser.Purchased do
+  import NimbleParsec
+
+  alias CsgoStats.Events
+  alias CsgoStats.Logs.Parser
+
+  # Example: "Ryan<13><BOT><TERRORIST>" purchased "negev"
+  def parser() do
+    ignore(string(" purchased "))
+    |> choice([
+      Parser.Weapon.parser(),
+      item()
+    ])
+    |> reduce({__MODULE__, :cast, []})
+  end
+
+  defp item() do
+    ignore(string(~s/"/))
+    |> choice([
+      string("defuser"),
+      ignore(string("item_"))
+      |> choice([
+        string("kevlar"),
+        string("assaultsuit")
+      ])
+    ])
+    |> ignore(string(~s/"/))
+    |> reduce({__MODULE__, :cast_item, []})
+  end
+
+  def cast_item([item]) do
+    case item do
+      "defuser" -> :defuser
+      "assaultsuit" -> :vesthelm
+      "kevlar" -> :vest
+    end
+  end
+
+  def cast([item]) do
+    %Events.Purchased{item: item}
+  end
+end

--- a/lib/csgo_stats/logs/parser/weapon.ex
+++ b/lib/csgo_stats/logs/parser/weapon.ex
@@ -2,10 +2,102 @@ defmodule CsgoStats.Logs.Parser.Weapon do
   import NimbleParsec
 
   # Example: "glock"
-  # TODO: atomize
   def parser() do
     ignore(string(~s/"/))
-    |> ascii_string([?a..?z, ?0..?9, ?_], min: 1)
+    |> concat(weapon_name())
     |> ignore(string(~s/"/))
+  end
+
+  def weapon_name() do
+    choice([
+      string("ak47"),
+      string("aug"),
+      string("awp"),
+      string("bizon"),
+      string("c4"),
+      string("deagle"),
+      string("decoy"),
+      string("elite"),
+      string("famas"),
+      string("flashbang"),
+      string("g3sg1"),
+      string("galilar"),
+      string("glock"),
+      string("hegrenade"),
+      string("hkp2000"),
+      string("incgrenade"),
+      string("inferno"),
+      string("knife_t"),
+      string("knife"),
+      string("m249"),
+      string("m4a1_silencer"),
+      string("m4a1"),
+      string("mac10"),
+      string("mag7"),
+      string("molotov"),
+      string("mp7"),
+      string("mp9"),
+      string("negev"),
+      string("nova"),
+      string("p250"),
+      string("p90"),
+      string("sawedoff"),
+      string("scar20"),
+      string("sg556"),
+      string("smokegrenade"),
+      string("ssg08"),
+      string("taser"),
+      string("tec9"),
+      string("ump45"),
+      string("usp_silencer"),
+      string("xm1014")
+    ])
+    |> reduce({__MODULE__, :cast, []})
+  end
+
+  def cast([weapon]) do
+    case weapon do
+      "ak47" -> :ak47
+      "aug" -> :aug
+      "awp" -> :awp
+      "bizon" -> :bizon
+      "c4" -> :c4
+      "deagle" -> :deagle
+      "decoy" -> :decoy
+      "elite" -> :elite
+      "famas" -> :famas
+      "flashbang" -> :flashbang
+      "g3sg1" -> :g3sg1
+      "galilar" -> :galilar
+      "glock" -> :glock
+      "hegrenade" -> :hegrenade
+      "hkp2000" -> :hkp2000
+      "incgrenade" -> :incgrenade
+      "inferno" -> :inferno
+      "knife" -> :knife
+      "knife_t" -> :knife_t
+      "m249" -> :m249
+      "m4a1" -> :m4a1
+      "m4a1_silencer" -> :m4a1_silencer
+      "mac10" -> :mac10
+      "mag7" -> :mag7
+      "molotov" -> :molotov
+      "mp7" -> :mp7
+      "mp9" -> :mp9
+      "negev" -> :negev
+      "nova" -> :nova
+      "p250" -> :p250
+      "p90" -> :p90
+      "sawedoff" -> :sawedoff
+      "scar20" -> :scar20
+      "sg556" -> :sg556
+      "smokegrenade" -> :smokegrenade
+      "ssg08" -> :ssg08
+      "taser" -> :taser
+      "tec9" -> :tec9
+      "ump45" -> :ump45
+      "usp_silencer" -> :usp_silencer
+      "xm1014" -> :xm1014
+    end
   end
 end

--- a/lib/csgo_stats/logs/parser/weapon.ex
+++ b/lib/csgo_stats/logs/parser/weapon.ex
@@ -15,6 +15,7 @@ defmodule CsgoStats.Logs.Parser.Weapon do
       string("awp"),
       string("bizon"),
       string("c4"),
+      string("cz75a"),
       string("deagle"),
       string("decoy"),
       string("elite"),
@@ -62,6 +63,7 @@ defmodule CsgoStats.Logs.Parser.Weapon do
       "awp" -> :awp
       "bizon" -> :bizon
       "c4" -> :c4
+      "cz75a" -> :cz75a
       "deagle" -> :deagle
       "decoy" -> :decoy
       "elite" -> :elite

--- a/lib/csgo_stats_web/templates/match/show.html.leex
+++ b/lib/csgo_stats_web/templates/match/show.html.leex
@@ -42,7 +42,9 @@
         <div class="table-row table-header">
           <div class="table-data"></div>
           <div class="table-data">+</div>
-          <div class="table-data">🛡️</div>
+          <div class="table-data">
+            <img src="<%= Routes.static_path(@socket, "/images/armor-icon.svg") %>" height="18px">
+          </div>
           <div class="table-data">$</div>
           <div class="table-data">K</div>
           <div class="table-data">A</div>

--- a/lib/csgo_stats_web/templates/match/show.html.leex
+++ b/lib/csgo_stats_web/templates/match/show.html.leex
@@ -42,6 +42,7 @@
         <div class="table-row table-header">
           <div class="table-data"></div>
           <div class="table-data">+</div>
+          <div class="table-data">🛡️</div>
           <div class="table-data">$</div>
           <div class="table-data">K</div>
           <div class="table-data">A</div>
@@ -51,8 +52,17 @@
         <div class="table-row">
           <div class="table-data"><%= username %></div>
           <div class="table-data">
-            <div class="progressbar <%= if player.health <= 75, do: 'yellow', else: '' %> <%= if player.health <= 40, do: 'red', else: '' %>" data-progress="<%= player.health %>">
+            <div
+              class="progressbar <%= if player.health <= 75, do: 'yellow', else: '' %> <%= if player.health <= 40, do: 'red', else: '' %>"
+              data-progress="<%= player.health %>">
               <span style="width: <%= player.health %>%;"></span>
+            </div>
+          </div>
+          <div class="table-data">
+            <div
+              class="progressbar <%= if player.armor <= 75, do: 'yellow', else: '' %> <%= if player.armor <= 40, do: 'red', else: '' %>"
+              data-progress="<%= player.armor %>">
+              <span style="width: <%= player.armor %>%;"></span>
             </div>
           </div>
           <div class="table-data"><%= player.money %></div>
@@ -84,8 +94,17 @@
         <div class="table-row">
           <div class="table-data"><%= username %></div>
           <div class="table-data">
-            <div class="progressbar <%= if player.health <= 75, do: 'yellow', else: '' %> <%= if player.health <= 40, do: 'red', else: '' %>" data-progress="<%= player.health %>">
+            <div
+              class="progressbar <%= if player.health <= 75, do: 'yellow', else: '' %> <%= if player.health <= 40, do: 'red', else: '' %>"
+              data-progress="<%= player.health %>">
               <span style="width: <%= player.health %>%;"></span>
+            </div>
+          </div>
+          <div class="table-data">
+            <div
+              class="progressbar <%= if player.armor <= 75, do: 'yellow', else: '' %> <%= if player.armor <= 40, do: 'red', else: '' %>"
+              data-progress="<%= player.armor %>">
+              <span style="width: <%= player.armor %>%;"></span>
             </div>
           </div>
           <div class="table-data"><%= player.money %></div>

--- a/test/csgo_stats/logs/parser_test.exs
+++ b/test/csgo_stats/logs/parser_test.exs
@@ -424,6 +424,29 @@ defmodule CsgoStats.Logs.ParserTest do
                 }
               ]} = Parser.parse(line)
     end
+
+    test "purchased" do
+      line = "12/11/2019 - 20:48:19.644 - \"Ryan<16><BOT><TERRORIST>\" purchased \"negev\""
+
+      assert {:ok,
+              [
+                %Events.Purchased{
+                  player: %{username: "Ryan"},
+                  item: :negev
+                }
+              ]} = Parser.parse(line)
+
+      line =
+        "12/11/2019 - 20:48:19.644 - \"Ryan<16><BOT><TERRORIST>\" purchased \"item_assaultsuit\""
+
+      assert {:ok,
+              [
+                %Events.Purchased{
+                  player: %{username: "Ryan"},
+                  item: :vesthelm
+                }
+              ]} = Parser.parse(line)
+    end
   end
 
   describe "multi-line parsing" do

--- a/test/csgo_stats/logs/parser_test.exs
+++ b/test/csgo_stats/logs/parser_test.exs
@@ -380,6 +380,28 @@ defmodule CsgoStats.Logs.ParserTest do
                 }
               ]} = Parser.parse(line)
     end
+
+    test "picked up" do
+      line = "12/11/2019 - 20:48:19.644 - \"George<21><BOT><CT>\" picked up \"hkp2000\""
+
+      assert {:ok,
+              [
+                %Events.PickedUp{
+                  player: %{username: "George"},
+                  item: :hkp2000
+                }
+              ]} = Parser.parse(line)
+
+      defuser = "12/11/2019 - 20:48:19.644 - \"George<21><BOT><CT>\" picked up \"defuser\""
+
+      assert {:ok,
+              [
+                %Events.PickedUp{
+                  player: %{username: "George"},
+                  item: :defuser
+                }
+              ]} = Parser.parse(defuser)
+    end
   end
 
   describe "multi-line parsing" do

--- a/test/csgo_stats/logs/parser_test.exs
+++ b/test/csgo_stats/logs/parser_test.exs
@@ -370,13 +370,14 @@ defmodule CsgoStats.Logs.ParserTest do
 
     test "left buyzone" do
       line =
-        "12/11/2019 - 20:48:19.644 - \"Fred<27><BOT><CT>\" left buyzone with [ weapon_knife weapon_hkp2000 ]"
+        "12/11/2019 - 20:48:19.644 - \"Fred<27><BOT><CT>\" left buyzone with [ weapon_knife weapon_hkp2000 weapon_c4 C4 ]"
 
       assert {:ok,
               [
                 %Events.LeftBuyzone{
                   player: %{username: "Fred"},
-                  weapons: [:knife, :hkp2000]
+                  weapons: [:knife, :hkp2000],
+                  c4: true
                 }
               ]} = Parser.parse(line)
     end

--- a/test/csgo_stats/logs/parser_test.exs
+++ b/test/csgo_stats/logs/parser_test.exs
@@ -145,7 +145,7 @@ defmodule CsgoStats.Logs.ParserTest do
                     steam_id: "BOT",
                     team: :terrorist
                   },
-                  weapon: "hkp2000",
+                  weapon: :hkp2000,
                   damage: 61,
                   damage_armor: 29,
                   health: 39,
@@ -162,7 +162,7 @@ defmodule CsgoStats.Logs.ParserTest do
                 %Events.Attacked{
                   attacker: %{username: "Clarence"},
                   attacked: %{username: "Niles"},
-                  weapon: "aug",
+                  weapon: :aug,
                   hitgroup: "left leg"
                 }
               ]} = Parser.parse(left_leg)
@@ -177,7 +177,7 @@ defmodule CsgoStats.Logs.ParserTest do
                 %Events.Killed{
                   killer: %{username: "Niles"},
                   killed: %{username: "Elmer"},
-                  weapon: "glock",
+                  weapon: :glock,
                   headshot: false,
                   penetrated: false
                 }
@@ -191,7 +191,7 @@ defmodule CsgoStats.Logs.ParserTest do
                 %Events.Killed{
                   killer: %{username: "Niles"},
                   killed: %{username: "Albert"},
-                  weapon: "knife_t",
+                  weapon: :knife_t,
                   headshot: false,
                   penetrated: false
                 }
@@ -205,7 +205,7 @@ defmodule CsgoStats.Logs.ParserTest do
                 %Events.Killed{
                   killer: %{username: "Niles"},
                   killed: %{username: "Albert"},
-                  weapon: "usp_silencer",
+                  weapon: :usp_silencer,
                   headshot: false,
                   penetrated: false
                 }
@@ -219,7 +219,7 @@ defmodule CsgoStats.Logs.ParserTest do
                 %Events.Killed{
                   killer: %{username: "tbroedsgaard"},
                   killed: %{username: "Yanni"},
-                  weapon: "glock",
+                  weapon: :glock,
                   headshot: true,
                   penetrated: false
                 }
@@ -233,7 +233,7 @@ defmodule CsgoStats.Logs.ParserTest do
                 %Events.Killed{
                   killer: %{username: "tbroedsgaard"},
                   killed: %{username: "Clarence"},
-                  weapon: "glock",
+                  weapon: :glock,
                   headshot: false,
                   penetrated: true
                 }
@@ -256,7 +256,7 @@ defmodule CsgoStats.Logs.ParserTest do
                 %Events.KilledOther{
                   killer: %{username: "tbroedsgaard"},
                   killed: "chicken",
-                  weapon: "awp",
+                  weapon: :awp,
                   penetrated: false,
                   headshot: false
                 }
@@ -270,7 +270,7 @@ defmodule CsgoStats.Logs.ParserTest do
                 %Events.KilledOther{
                   killer: %{username: "tbroedsgaard"},
                   killed: "chicken",
-                  weapon: "awp",
+                  weapon: :awp,
                   penetrated: false,
                   headshot: true
                 }
@@ -284,7 +284,7 @@ defmodule CsgoStats.Logs.ParserTest do
                 %Events.KilledOther{
                   killer: %{username: "Yogi"},
                   killed: "func_breakable",
-                  weapon: "mp7",
+                  weapon: :mp7,
                   penetrated: true,
                   headshot: false
                 }
@@ -366,6 +366,19 @@ defmodule CsgoStats.Logs.ParserTest do
                   purchase: "weapon_xm1014"
                 }
               ]} = Parser.parse(purchase)
+    end
+
+    test "left buyzone" do
+      line =
+        "12/11/2019 - 20:48:19.644 - \"Fred<27><BOT><CT>\" left buyzone with [ weapon_knife weapon_hkp2000 ]"
+
+      assert {:ok,
+              [
+                %Events.LeftBuyzone{
+                  player: %{username: "Fred"},
+                  weapons: [:knife, :hkp2000]
+                }
+              ]} = Parser.parse(line)
     end
   end
 

--- a/test/csgo_stats/logs/parser_test.exs
+++ b/test/csgo_stats/logs/parser_test.exs
@@ -401,6 +401,28 @@ defmodule CsgoStats.Logs.ParserTest do
                   item: :defuser
                 }
               ]} = Parser.parse(defuser)
+
+      c4 = "12/11/2019 - 20:48:19.644 - \"George<21><BOT><CT>\" picked up \"c4\""
+
+      assert {:ok,
+              [
+                %Events.PickedUp{
+                  player: %{username: "George"},
+                  item: :c4
+                }
+              ]} = Parser.parse(c4)
+    end
+
+    test "dropped" do
+      line = "12/11/2019 - 20:48:19.644 - \"Wesley<16><BOT><TERRORIST>\" dropped \"glock\""
+
+      assert {:ok,
+              [
+                %Events.Dropped{
+                  player: %{username: "Wesley"},
+                  item: :glock
+                }
+              ]} = Parser.parse(line)
     end
   end
 


### PR DESCRIPTION
Closes #23 

Note that I ended up not using the `LeftBuyzone` event since `Dropped`, `PickedUp` and `Purchased` seem to cover the use case fully. Also, I'm not showing any equipment on the scoreboard - I'll wait for when the icons land.

Also, I'm not sure why the progressbar for armor is not the same width as health, maybe you can help me out here 😂 