### PR TITLE
Add types to events and use these to check the parser

### DIFF
--- a/lib/csgo_stats/events/accolade.ex
+++ b/lib/csgo_stats/events/accolade.ex
@@ -1,3 +1,14 @@
 defmodule CsgoStats.Events.Accolade do
+  alias CsgoStats.Types
+
+  @type t() :: %__MODULE__{
+          award: Types.award(),
+          player: Types.player(),
+          value: float(),
+          position: integer(),
+          score: float(),
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [:award, :player, :value, :position, :score, :timestamp]
 end

--- a/lib/csgo_stats/events/assisted.ex
+++ b/lib/csgo_stats/events/assisted.ex
@@ -1,3 +1,11 @@
 defmodule CsgoStats.Events.Assisted do
+  alias CsgoStats.Types
+
+  @type t() :: %__MODULE__{
+          assistant: Types.player(),
+          killed: Types.player(),
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [:assistant, :killed, :timestamp]
 end

--- a/lib/csgo_stats/events/attacked.ex
+++ b/lib/csgo_stats/events/attacked.ex
@@ -1,4 +1,18 @@
 defmodule CsgoStats.Events.Attacked do
+  alias CsgoStats.Types
+
+  @type t() :: %__MODULE__{
+          attacker: Types.player(),
+          attacked: Types.player(),
+          weapon: Types.weapon(),
+          damage: integer(),
+          damage_armor: integer(),
+          health: integer(),
+          armor: integer(),
+          hitgroup: Types.hitgroup(),
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [
     :attacker,
     :attacked,

--- a/lib/csgo_stats/events/began_bomb_defuse.ex
+++ b/lib/csgo_stats/events/began_bomb_defuse.ex
@@ -1,3 +1,9 @@
 defmodule CsgoStats.Events.BeganBombDefuse do
+  @type t() :: %__MODULE__{
+          player: CsgoStats.Types.player(),
+          kit: boolean(),
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [:player, :kit, :timestamp]
 end

--- a/lib/csgo_stats/events/defused_the_bomb.ex
+++ b/lib/csgo_stats/events/defused_the_bomb.ex
@@ -1,3 +1,8 @@
 defmodule CsgoStats.Events.DefusedTheBomb do
+  @type t() :: %__MODULE__{
+          player: CsgoStats.Types.player(),
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [:player, :timestamp]
 end

--- a/lib/csgo_stats/events/dropped.ex
+++ b/lib/csgo_stats/events/dropped.ex
@@ -1,3 +1,11 @@
 defmodule CsgoStats.Events.Dropped do
+  alias CsgoStats.Types
+
+  @type t() :: %__MODULE__{
+          player: Types.player(),
+          item: Types.weapon() | Types.item(),
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [:player, :item, :timestamp]
 end

--- a/lib/csgo_stats/events/dropped_the_bomb.ex
+++ b/lib/csgo_stats/events/dropped_the_bomb.ex
@@ -1,3 +1,8 @@
 defmodule CsgoStats.Events.DroppedTheBomb do
+  @type t() :: %__MODULE__{
+          player: CsgoStats.Types.player(),
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [:player, :timestamp]
 end

--- a/lib/csgo_stats/events/freeze_period_started.ex
+++ b/lib/csgo_stats/events/freeze_period_started.ex
@@ -1,3 +1,4 @@
 defmodule CsgoStats.Events.FreezePeriodStarted do
+  @type t() :: %__MODULE__{timestamp: NaiveDateTime.t()}
   defstruct [:timestamp]
 end

--- a/lib/csgo_stats/events/game_commencing.ex
+++ b/lib/csgo_stats/events/game_commencing.ex
@@ -1,3 +1,4 @@
 defmodule CsgoStats.Events.GameCommencing do
+  @type t() :: %__MODULE__{timestamp: NaiveDateTime.t()}
   defstruct [:timestamp]
 end

--- a/lib/csgo_stats/events/game_over.ex
+++ b/lib/csgo_stats/events/game_over.ex
@@ -1,3 +1,14 @@
 defmodule CsgoStats.Events.GameOver do
+  alias CsgoStats.Types
+
+  @type t() :: %__MODULE__{
+          game_mode: Types.game_mode(),
+          game_map: Types.game_map(),
+          ct_score: integer(),
+          t_score: integer(),
+          duration: integer(),
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [:game_mode, :game_map, :ct_score, :t_score, :duration, :timestamp]
 end

--- a/lib/csgo_stats/events/got_the_bomb.ex
+++ b/lib/csgo_stats/events/got_the_bomb.ex
@@ -1,3 +1,7 @@
 defmodule CsgoStats.Events.GotTheBomb do
+  @type t() :: %__MODULE__{
+          player: CsgoStats.Types.player(),
+          timestamp: NaiveDateTime.t()
+        }
   defstruct [:player, :timestamp]
 end

--- a/lib/csgo_stats/events/killed.ex
+++ b/lib/csgo_stats/events/killed.ex
@@ -1,3 +1,14 @@
 defmodule CsgoStats.Events.Killed do
+  alias CsgoStats.Types
+
+  @type t() :: %__MODULE__{
+          killer: Types.player(),
+          killed: Types.player(),
+          weapon: Types.weapon(),
+          headshot: boolean(),
+          penetrated: boolean(),
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [:killer, :killed, :weapon, :headshot, :penetrated, :timestamp]
 end

--- a/lib/csgo_stats/events/killed_by_the_bomb.ex
+++ b/lib/csgo_stats/events/killed_by_the_bomb.ex
@@ -1,3 +1,7 @@
 defmodule CsgoStats.Events.KilledByTheBomb do
+  @type t() :: %__MODULE__{
+          player: CsgoStats.Types.player(),
+          timestamp: NaiveDateTime.t()
+        }
   defstruct [:player, :timestamp]
 end

--- a/lib/csgo_stats/events/killed_other.ex
+++ b/lib/csgo_stats/events/killed_other.ex
@@ -1,3 +1,14 @@
 defmodule CsgoStats.Events.KilledOther do
+  alias CsgoStats.Types
+
+  @type t() :: %__MODULE__{
+          killed: Types.player(),
+          killed: Types.killable(),
+          weapon: Types.weapon(),
+          headshot: boolean(),
+          penetrated: boolean(),
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [:killer, :killed, :weapon, :headshot, :penetrated, :timestamp]
 end

--- a/lib/csgo_stats/events/left_buyzone.ex
+++ b/lib/csgo_stats/events/left_buyzone.ex
@@ -1,3 +1,15 @@
 defmodule CsgoStats.Events.LeftBuyzone do
+  alias CsgoStats.Types
+
+  @type t() :: %__MODULE__{
+          player: Types.player(),
+          c4: boolean(),
+          defuser: boolean(),
+          helmet: boolean(),
+          kevlar: integer(),
+          weapons: list(Types.weapon()),
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [:player, :c4, :defuser, :helmet, :kevlar, :weapons, :timestamp]
 end

--- a/lib/csgo_stats/events/match_start.ex
+++ b/lib/csgo_stats/events/match_start.ex
@@ -1,3 +1,8 @@
 defmodule CsgoStats.Events.MatchStart do
-  defstruct [:map, :timestamp]
+  @type t() :: %__MODULE__{
+          game_map: CsgoStats.Types.game_map(),
+          timestamp: NaiveDateTime.t()
+        }
+
+  defstruct [:game_map, :timestamp]
 end

--- a/lib/csgo_stats/events/money_change.ex
+++ b/lib/csgo_stats/events/money_change.ex
@@ -1,3 +1,14 @@
 defmodule CsgoStats.Events.MoneyChange do
+  alias CsgoStats.Types
+
+  @type t() :: %__MODULE__{
+          player: Types.player(),
+          previous: integer(),
+          diff: integer(),
+          result: integer(),
+          purchase: Types.weapon() | Types.item() | nil,
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [:player, :previous, :diff, :result, :purchase, :timestamp]
 end

--- a/lib/csgo_stats/events/picked_up.ex
+++ b/lib/csgo_stats/events/picked_up.ex
@@ -1,3 +1,11 @@
 defmodule CsgoStats.Events.PickedUp do
+  alias CsgoStats.Types
+
+  @type t() :: %__MODULE__{
+          player: Types.player(),
+          item: Types.weapon() | Types.item(),
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [:player, :item, :timestamp]
 end

--- a/lib/csgo_stats/events/planted_the_bomb.ex
+++ b/lib/csgo_stats/events/planted_the_bomb.ex
@@ -1,3 +1,7 @@
 defmodule CsgoStats.Events.PlantedTheBomb do
+  @type t() :: %__MODULE__{
+          player: CsgoStats.Types.player(),
+          timestamp: NaiveDateTime.t()
+        }
   defstruct [:player, :timestamp]
 end

--- a/lib/csgo_stats/events/player_connected.ex
+++ b/lib/csgo_stats/events/player_connected.ex
@@ -1,3 +1,9 @@
 defmodule CsgoStats.Events.PlayerConnected do
+  @type t() :: %__MODULE__{
+          player: CsgoStats.Types.player(),
+          address: String.t() | nil,
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [:player, :address, :timestamp]
 end

--- a/lib/csgo_stats/events/player_disconnected.ex
+++ b/lib/csgo_stats/events/player_disconnected.ex
@@ -1,3 +1,9 @@
 defmodule CsgoStats.Events.PlayerDisconnected do
+  @type t() :: %__MODULE__{
+          player: CsgoStats.Types.player(),
+          reason: :disconnect | :kicked_by_console | :server_shutting_down,
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [:player, :reason, :timestamp]
 end

--- a/lib/csgo_stats/events/player_entered_the_game.ex
+++ b/lib/csgo_stats/events/player_entered_the_game.ex
@@ -1,3 +1,7 @@
 defmodule CsgoStats.Events.PlayerEnteredTheGame do
+  @type t() :: %__MODULE__{
+          player: CsgoStats.Types.player(),
+          timestamp: NaiveDateTime.t()
+        }
   defstruct [:player, :timestamp]
 end

--- a/lib/csgo_stats/events/player_switched_team.ex
+++ b/lib/csgo_stats/events/player_switched_team.ex
@@ -1,3 +1,12 @@
 defmodule CsgoStats.Events.PlayerSwitchedTeam do
+  alias CsgoStats.Types
+
+  @type t() :: %__MODULE__{
+          player: Types.player(),
+          from: Types.team(),
+          to: Types.team(),
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [:player, :from, :to, :timestamp]
 end

--- a/lib/csgo_stats/events/purchased.ex
+++ b/lib/csgo_stats/events/purchased.ex
@@ -1,3 +1,11 @@
 defmodule CsgoStats.Events.Purchased do
+  alias CsgoStats.Types
+
+  @type t() :: %__MODULE__{
+          player: Types.player(),
+          item: Types.weapon() | Types.item(),
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [:player, :item, :timestamp]
 end

--- a/lib/csgo_stats/events/round_end.ex
+++ b/lib/csgo_stats/events/round_end.ex
@@ -1,3 +1,4 @@
 defmodule CsgoStats.Events.RoundEnd do
+  @type t() :: %__MODULE__{timestamp: NaiveDateTime.t()}
   defstruct [:timestamp]
 end

--- a/lib/csgo_stats/events/round_start.ex
+++ b/lib/csgo_stats/events/round_start.ex
@@ -1,3 +1,4 @@
 defmodule CsgoStats.Events.RoundStart do
+  @type t() :: %__MODULE__{timestamp: NaiveDateTime.t()}
   defstruct [:timestamp]
 end

--- a/lib/csgo_stats/events/team_won.ex
+++ b/lib/csgo_stats/events/team_won.ex
@@ -1,3 +1,12 @@
 defmodule CsgoStats.Events.TeamWon do
+  alias CsgoStats.Types
+
+  @type t() :: %__MODULE__{
+          team: :ct | :terrorist,
+          win_condition: Types.win_condition(),
+          ct_score: integer(),
+          terrorist_score: integer(),
+          timestamp: NaiveDateTime.t()
+        }
   defstruct [:team, :win_condition, :ct_score, :terrorist_score, :timestamp]
 end

--- a/lib/csgo_stats/events/terrorists_win.ex
+++ b/lib/csgo_stats/events/terrorists_win.ex
@@ -1,3 +1,0 @@
-defmodule CsgoStats.Events.TerroristsWin do
-  defstruct [:ct_score, :terrorist_score, :timestamp]
-end

--- a/lib/csgo_stats/events/threw_grenade.ex
+++ b/lib/csgo_stats/events/threw_grenade.ex
@@ -1,3 +1,11 @@
 defmodule CsgoStats.Events.ThrewGrenade do
+  alias CsgoStats.Types
+
+  @type t() :: %__MODULE__{
+          player: Types.player(),
+          item: Types.grenade(),
+          timestamp: NaiveDateTime.t()
+        }
+
   defstruct [:player, :item, :timestamp]
 end

--- a/lib/csgo_stats/logs/parser/accolade.ex
+++ b/lib/csgo_stats/logs/parser/accolade.ex
@@ -1,13 +1,17 @@
 defmodule CsgoStats.Logs.Parser.Accolade do
   import NimbleParsec
 
-  alias CsgoStats.Events
+  alias CsgoStats.{Events, Types}
   alias CsgoStats.Logs.Parser
+
+  @awards Enum.map(Types.awards(), fn award ->
+            string(to_string(award))
+          end)
 
   # ACCOLADE, FINAL: {3k},	Neil<8>,	VALUE: 1.000000,	POS: 2,	SCORE: 20.000002
   def parser() do
     ignore(string("ACCOLADE, FINAL: {"))
-    |> concat(award())
+    |> choice(@awards)
     |> ignore(string("},\t"))
     |> concat(Parser.Username.parser())
     |> concat(Parser.UserTag.parser())
@@ -20,30 +24,8 @@ defmodule CsgoStats.Logs.Parser.Accolade do
     |> reduce({__MODULE__, :cast, []})
   end
 
-  # Example: "3k"
-  defp award() do
-    choice([
-      string("3k"),
-      string("hsp"),
-      string("firstkills"),
-      string("cashspent"),
-      string("deaths"),
-      string("mvps"),
-      string("assists")
-    ])
-  end
-
   def cast([award, player, _tag, value, position, score]) do
-    award =
-      case award do
-        "3k" -> :"3k"
-        "hsp" -> :hsp
-        "firstkills" -> :firstkills
-        "cashspent" -> :cashspent
-        "deaths" -> :deaths
-        "mvps" -> :mvps
-        "assists" -> :assists
-      end
+    award = String.to_existing_atom(award)
 
     %Events.Accolade{
       award: award,

--- a/lib/csgo_stats/logs/parser/began_bomb_defuse.ex
+++ b/lib/csgo_stats/logs/parser/began_bomb_defuse.ex
@@ -6,13 +6,19 @@ defmodule CsgoStats.Logs.Parser.BeganBombDefuse do
   # Example: "Clarence<17><BOT><CT>" triggered "Begin_Bomb_Defuse_With_Kit"
   def parser() do
     ignore(string(~s/ triggered "/))
-    |> string("Begin_Bomb_Defuse_With_Kit")
+    |> choice([
+      string("Begin_Bomb_Defuse_With_Kit"),
+      string("Begin_Bomb_Defuse_Without_Kit")
+    ])
     |> ignore(string(~s/"/))
     |> reduce({__MODULE__, :cast, []})
   end
 
-  # TODO: Handle Without_Kit
   def cast(["Begin_Bomb_Defuse_With_Kit"]) do
     %Events.BeganBombDefuse{kit: true}
+  end
+
+  def cast(["Begin_Bomb_Defuse_Without_Kit"]) do
+    %Events.BeganBombDefuse{kit: false}
   end
 end

--- a/lib/csgo_stats/logs/parser/dropped.ex
+++ b/lib/csgo_stats/logs/parser/dropped.ex
@@ -9,28 +9,9 @@ defmodule CsgoStats.Logs.Parser.Dropped do
     ignore(string(" dropped "))
     |> choice([
       Parser.Weapon.parser(),
-      item()
+      Parser.Item.parser()
     ])
     |> reduce({__MODULE__, :cast, []})
-  end
-
-  defp item() do
-    ignore(string(~s/"/))
-    |> choice([
-      string("defuser"),
-      string("vesthelm"),
-      string("vest")
-    ])
-    |> ignore(string(~s/"/))
-    |> reduce({__MODULE__, :cast_item, []})
-  end
-
-  def cast_item([item]) do
-    case item do
-      "defuser" -> :defuser
-      "vesthelm" -> :vesthelm
-      "vest" -> :vest
-    end
   end
 
   def cast([item]) do

--- a/lib/csgo_stats/logs/parser/game_map.ex
+++ b/lib/csgo_stats/logs/parser/game_map.ex
@@ -1,31 +1,19 @@
 defmodule CsgoStats.Logs.Parser.GameMap do
   import NimbleParsec
 
+  alias CsgoStats.Types
+
+  @maps Enum.map(Types.game_maps(), fn map ->
+          string(to_string(map))
+        end)
+
   # Example: "de_inferno"
   def parser() do
-    choice([
-      string("de_cache"),
-      string("de_vertigo"),
-      string("de_dust2"),
-      string("de_inferno"),
-      string("de_mirage"),
-      string("de_nuke"),
-      string("de_overpass"),
-      string("de_train")
-    ])
+    choice(@maps)
     |> reduce({__MODULE__, :cast, []})
   end
 
   def cast([map]) do
-    case map do
-      "de_cache" -> :de_cache
-      "de_vertigo" -> :de_vertigo
-      "de_dust2" -> :de_dust2
-      "de_inferno" -> :de_inferno
-      "de_mirage" -> :de_mirage
-      "de_nuke" -> :de_nuke
-      "de_overpass" -> :de_overpass
-      "de_train" -> :de_train
-    end
+    String.to_existing_atom(map)
   end
 end

--- a/lib/csgo_stats/logs/parser/item.ex
+++ b/lib/csgo_stats/logs/parser/item.ex
@@ -1,0 +1,41 @@
+defmodule CsgoStats.Logs.Parser.Item do
+  import NimbleParsec
+
+  alias CsgoStats.Types
+
+  # Example: "defuser"
+  def parser() do
+    ignore(string(~s/"/))
+    |> choice([
+      string("c4"),
+      string("defuser"),
+      string("vesthelm"),
+      string("vest")
+    ])
+    |> ignore(string(~s/"/))
+    |> reduce({__MODULE__, :cast, []})
+  end
+
+  # Example: item_defuser
+  def prefixed() do
+    ignore(string(~s/"item_/))
+    |> choice([
+      string("defuser"),
+      string("kevlar"),
+      string("assaultsuit")
+    ])
+    |> ignore(string(~s/"/))
+    |> reduce({__MODULE__, :cast, []})
+  end
+
+  Enum.each(Types.items(), fn
+    :c4 -> defp cast_item("c4"), do: :c4
+    :defuser -> defp cast_item("defuser"), do: :defuser
+    :vest -> defp cast_item(item) when item in ["vest", "kevlar"], do: :vest
+    :vesthelm -> defp cast_item(item) when item in ["vesthelm", "assaultsuit"], do: :vesthelm
+  end)
+
+  def cast([item]) do
+    cast_item(item)
+  end
+end

--- a/lib/csgo_stats/logs/parser/killed_other.ex
+++ b/lib/csgo_stats/logs/parser/killed_other.ex
@@ -1,15 +1,19 @@
 defmodule CsgoStats.Logs.Parser.KilledOther do
   import NimbleParsec
 
-  alias CsgoStats.Events
+  alias CsgoStats.{Events, Types}
   alias CsgoStats.Logs.Parser
+
+  @killables Enum.map(Types.killables(), fn killable ->
+               string(to_string(killable))
+             end)
 
   # Example: "tbroedsgaard<12><STEAM_1:1:42376214><TERRORIST>" [849 2387 143] killed other "chicken<159>" [814 2555 138] with "awp"
   def parser() do
     ignore(string(" "))
     |> ignore(Parser.Position.parser())
     |> ignore(string(~s/ killed other "/))
-    |> choice([string("chicken"), string("func_breakable")])
+    |> choice(@killables)
     |> ignore(ascii_string([?0..?9, ?<, ?>, ?"], min: 1))
     |> ignore(string(" "))
     |> ignore(Parser.Position.parser())
@@ -20,6 +24,8 @@ defmodule CsgoStats.Logs.Parser.KilledOther do
   end
 
   def cast([killed, weapon]) do
+    killed = String.to_existing_atom(killed)
+
     %Events.KilledOther{
       killed: killed,
       weapon: weapon,
@@ -31,6 +37,7 @@ defmodule CsgoStats.Logs.Parser.KilledOther do
   def cast([killed, weapon, extra]) do
     event = cast([killed, weapon])
 
+    # TODO: Handle headshots that penetrated
     case extra do
       " (headshot)" -> %{event | headshot: true}
       " (penetrated)" -> %{event | penetrated: true}

--- a/lib/csgo_stats/logs/parser/left_buyzone.ex
+++ b/lib/csgo_stats/logs/parser/left_buyzone.ex
@@ -22,6 +22,7 @@ defmodule CsgoStats.Logs.Parser.LeftBuyzone do
     choice([
       weapon(),
       kevlar(),
+      string("weapon_c4"),
       string("C4"),
       string("defuser"),
       string("helmet")
@@ -29,8 +30,7 @@ defmodule CsgoStats.Logs.Parser.LeftBuyzone do
   end
 
   defp weapon() do
-    ignore(string("weapon_"))
-    |> concat(Parser.Weapon.weapon_name())
+    Parser.Weapon.prefixed()
     |> reduce({__MODULE__, :cast_weapon, []})
   end
 
@@ -47,10 +47,9 @@ defmodule CsgoStats.Logs.Parser.LeftBuyzone do
       items,
       %Events.LeftBuyzone{weapons: [], defuser: false, c4: false, helmet: false, kevlar: 0},
       fn
-        # Skip {:weapon, :c4} as these buyzone events also contain "C4"
-        {:weapon, :c4}, acc -> acc
         {:weapon, weapon}, acc -> %{acc | weapons: acc.weapons ++ [weapon]}
         {:kevlar, hitpoints}, acc -> %{acc | kevlar: hitpoints}
+        "weapon_c4", acc -> %{acc | c4: true}
         "C4", acc -> %{acc | c4: true}
         "defuser", acc -> %{acc | defuser: true}
         "helmet", acc -> %{acc | helmet: true}

--- a/lib/csgo_stats/logs/parser/match_start.ex
+++ b/lib/csgo_stats/logs/parser/match_start.ex
@@ -12,7 +12,7 @@ defmodule CsgoStats.Logs.Parser.MatchStart do
     |> reduce({__MODULE__, :cast, []})
   end
 
-  def cast([map]) do
-    %Events.MatchStart{map: map}
+  def cast([game_map]) do
+    %Events.MatchStart{game_map: game_map}
   end
 end

--- a/lib/csgo_stats/logs/parser/money_change.ex
+++ b/lib/csgo_stats/logs/parser/money_change.ex
@@ -2,8 +2,8 @@ defmodule CsgoStats.Logs.Parser.MoneyChange do
   import NimbleParsec
 
   alias CsgoStats.Events
+  alias CsgoStats.Logs.Parser
 
-  # Example: "Uri<8><BOT><CT>" money change 3000-2000 = $1000 (tracked) (purchase: weapon_xm1014)
   def parser() do
     ignore(string(" money change "))
     |> integer(min: 1)
@@ -17,14 +17,13 @@ defmodule CsgoStats.Logs.Parser.MoneyChange do
     |> ignore(string(" (tracked)"))
     |> optional(
       ignore(string(" (purchase: "))
-      |> concat(item())
+      |> choice([
+        Parser.Weapon.prefixed(),
+        Parser.Item.prefixed()
+      ])
       |> ignore(string(")"))
     )
     |> reduce({__MODULE__, :cast, []})
-  end
-
-  defp item() do
-    ascii_string([?a..?z, ?0..?9, ?_], min: 1)
   end
 
   def cast([previous, sign, diff_absolute, result]) do
@@ -41,7 +40,6 @@ defmodule CsgoStats.Logs.Parser.MoneyChange do
     }
   end
 
-  # TODO: atomize purchase
   def cast([previous, sign, diff_absolute, result, purchase]) do
     event = cast([previous, sign, diff_absolute, result])
     %{event | purchase: purchase}

--- a/lib/csgo_stats/logs/parser/picked_up.ex
+++ b/lib/csgo_stats/logs/parser/picked_up.ex
@@ -9,18 +9,9 @@ defmodule CsgoStats.Logs.Parser.PickedUp do
     ignore(string(" picked up "))
     |> choice([
       Parser.Weapon.parser(),
-      defuser()
+      Parser.Item.parser()
     ])
     |> reduce({__MODULE__, :cast, []})
-  end
-
-  defp defuser() do
-    ignore(string(~s/"defuser"/))
-    |> reduce({__MODULE__, :cast_defuser, []})
-  end
-
-  def cast_defuser([]) do
-    :defuser
   end
 
   def cast([item]) do

--- a/lib/csgo_stats/logs/parser/player_disconnected.ex
+++ b/lib/csgo_stats/logs/parser/player_disconnected.ex
@@ -1,23 +1,28 @@
 defmodule CsgoStats.Logs.Parser.PlayerDisconnected do
   import NimbleParsec
 
-  alias CsgoStats.Events
+  alias CsgoStats.{Events, Types}
 
   # Example: "tbroedsgaard<12><STEAM_1:1:42376214><Unassigned>" disconnected (reason "Disconnect")
   def parser() do
     ignore(string(~s/ disconnected (reason "/))
-    |> choice([string("Disconnect"), string("Kicked by Console")])
+    |> choice([
+      string("Disconnect"),
+      string("Kicked by Console"),
+      string("Server shutting down")
+    ])
     |> ignore(string(~s/")/))
     |> reduce({__MODULE__, :cast, []})
   end
 
-  def cast([reason]) do
-    reason =
-      case reason do
-        "Disconnect" -> :disconnect
-        "Kicked by Console" -> :kicked_by_console
-      end
+  Enum.each(Types.disconnect_reasons(), fn
+    :disconnect -> defp cast_reason("Disconnect"), do: :disconnect
+    :kicked_by_console -> defp cast_reason("Kicked by Console"), do: :kicked_by_console
+    :server_shutting_down -> defp cast_reason("Server shutting down"), do: :server_shutting_down
+  end)
 
+  def cast([reason]) do
+    reason = cast_reason(reason)
     %Events.PlayerDisconnected{reason: reason}
   end
 end

--- a/lib/csgo_stats/logs/parser/purchased.ex
+++ b/lib/csgo_stats/logs/parser/purchased.ex
@@ -9,31 +9,9 @@ defmodule CsgoStats.Logs.Parser.Purchased do
     ignore(string(" purchased "))
     |> choice([
       Parser.Weapon.parser(),
-      item()
+      Parser.Item.prefixed()
     ])
     |> reduce({__MODULE__, :cast, []})
-  end
-
-  defp item() do
-    ignore(string(~s/"/))
-    |> choice([
-      string("defuser"),
-      ignore(string("item_"))
-      |> choice([
-        string("kevlar"),
-        string("assaultsuit")
-      ])
-    ])
-    |> ignore(string(~s/"/))
-    |> reduce({__MODULE__, :cast_item, []})
-  end
-
-  def cast_item([item]) do
-    case item do
-      "defuser" -> :defuser
-      "assaultsuit" -> :vesthelm
-      "kevlar" -> :vest
-    end
   end
 
   def cast([item]) do

--- a/lib/csgo_stats/logs/parser/team.ex
+++ b/lib/csgo_stats/logs/parser/team.ex
@@ -1,18 +1,28 @@
 defmodule CsgoStats.Logs.Parser.Team do
   import NimbleParsec
 
+  alias CsgoStats.Types
+
   # Example: CT
   def parser() do
-    choice([string("CT"), string("TERRORIST"), string("T"), string("Unassigned")])
+    choice([
+      string("CT"),
+      string("TERRORIST"),
+      string("T"),
+      string("Unassigned"),
+      string("Spectator")
+    ])
     |> reduce({__MODULE__, :cast, []})
   end
 
+  Enum.each(Types.teams(), fn
+    :ct -> defp cast_team("CT"), do: :ct
+    :terrorist -> defp cast_team(team) when team in ["T", "TERRORIST"], do: :terrorist
+    :unassigned -> defp cast_team("Unassigned"), do: :unassigned
+    :spectator -> defp cast_team("Spectator"), do: :spectator
+  end)
+
   def cast([team]) do
-    case team do
-      "CT" -> :ct
-      "TERRORIST" -> :terrorist
-      "T" -> :terrorist
-      "Unassigned" -> nil
-    end
+    cast_team(team)
   end
 end

--- a/lib/csgo_stats/logs/parser/team_won.ex
+++ b/lib/csgo_stats/logs/parser/team_won.ex
@@ -1,7 +1,7 @@
 defmodule CsgoStats.Logs.Parser.TeamWon do
   import NimbleParsec
 
-  alias CsgoStats.Events
+  alias CsgoStats.{Events, Types}
   alias CsgoStats.Logs.Parser
 
   # Example: Team "TERRORIST" triggered "SFUI_Notice_Terrorists_Win" (CT "0") (T "1")
@@ -29,6 +29,14 @@ defmodule CsgoStats.Logs.Parser.TeamWon do
     ])
   end
 
+  Enum.each(Types.win_conditions(), fn
+    :terrorists_win -> defp cast_win_condition("Terrorists_Win"), do: :terrorists_win
+    :cts_win -> defp cast_win_condition("CTs_Win"), do: :cts_win
+    :target_bombed -> defp cast_win_condition("Target_Bombed"), do: :target_bombed
+    :bomb_defused -> defp cast_win_condition("Bomb_Defused"), do: :bomb_defused
+    :target_saved -> defp cast_win_condition("Target_Saved"), do: :target_saved
+  end)
+
   # Example: (CT "0")
   defp team_score() do
     ignore(string("("))
@@ -39,14 +47,7 @@ defmodule CsgoStats.Logs.Parser.TeamWon do
   end
 
   def cast([team, win_condition, :ct, ct_score, :terrorist, terrorist_score]) do
-    win_condition =
-      case win_condition do
-        "Terrorists_Win" -> :terrorists_win
-        "CTs_Win" -> :cts_win
-        "Target_Bombed" -> :target_bombed
-        "Bomb_Defused" -> :bomb_defused
-        "Target_Saved" -> :target_saved
-      end
+    win_condition = cast_win_condition(win_condition)
 
     %Events.TeamWon{
       team: team,

--- a/lib/csgo_stats/logs/parser/threw_grenade.ex
+++ b/lib/csgo_stats/logs/parser/threw_grenade.ex
@@ -1,17 +1,21 @@
 defmodule CsgoStats.Logs.Parser.ThrewGrenade do
   import NimbleParsec
 
-  alias CsgoStats.Events
-  alias CsgoStats.Logs.Parser
+  alias CsgoStats.{Events, Types}
+
+  @grenades Enum.map(Types.grenades(), fn grenade ->
+              string(to_string(grenade))
+            end)
 
   # Example: "Ryan<13><BOT><TERRORIST>" threw flashbang [1333 376 179] flashbang entindex 239)
   def parser() do
     ignore(string(" threw "))
-    |> concat(Parser.Weapon.grenade_name())
+    |> choice(@grenades)
     |> reduce({__MODULE__, :cast, []})
   end
 
   def cast([item]) do
+    item = String.to_existing_atom(item)
     %Events.ThrewGrenade{item: item}
   end
 end

--- a/lib/csgo_stats/logs/parser/weapon.ex
+++ b/lib/csgo_stats/logs/parser/weapon.ex
@@ -1,115 +1,30 @@
 defmodule CsgoStats.Logs.Parser.Weapon do
   import NimbleParsec
 
-  @weapons [
-    string("ak47"),
-    string("aug"),
-    string("awp"),
-    string("bizon"),
-    string("c4"),
-    string("cz75a"),
-    string("deagle"),
-    string("elite"),
-    string("famas"),
-    string("g3sg1"),
-    string("galilar"),
-    string("glock"),
-    string("hkp2000"),
-    string("knife_t"),
-    string("knife"),
-    string("m249"),
-    string("m4a1_silencer"),
-    string("m4a1"),
-    string("mac10"),
-    string("mag7"),
-    string("mp7"),
-    string("mp9"),
-    string("negev"),
-    string("nova"),
-    string("p250"),
-    string("p90"),
-    string("sawedoff"),
-    string("scar20"),
-    string("sg556"),
-    string("ssg08"),
-    string("taser"),
-    string("tec9"),
-    string("ump45"),
-    string("usp_silencer"),
-    string("xm1014")
-  ]
+  alias CsgoStats.Types
 
-  @grenades [
-    string("smokegrenade"),
-    string("flashbang"),
-    string("incgrenade"),
-    string("hegrenade"),
-    string("inferno"),
-    string("molotov"),
-    string("decoy")
-  ]
+  @weapons Enum.map(Types.weapons(), fn weapon ->
+             string(to_string(weapon))
+           end)
 
   # Example: "glock"
   def parser() do
     ignore(string(~s/"/))
-    |> concat(weapon_name())
+    |> concat(weapon())
     |> ignore(string(~s/"/))
   end
 
-  def weapon_name() do
-    choice(@weapons ++ @grenades)
-    |> reduce({__MODULE__, :cast, []})
+  def prefixed() do
+    ignore(string("weapon_"))
+    |> concat(weapon())
   end
 
-  def grenade_name() do
-    choice(@grenades)
+  defp weapon() do
+    choice(@weapons)
     |> reduce({__MODULE__, :cast, []})
   end
 
   def cast([weapon]) do
-    case weapon do
-      "ak47" -> :ak47
-      "aug" -> :aug
-      "awp" -> :awp
-      "bizon" -> :bizon
-      "c4" -> :c4
-      "cz75a" -> :cz75a
-      "deagle" -> :deagle
-      "decoy" -> :decoy
-      "elite" -> :elite
-      "famas" -> :famas
-      "flashbang" -> :flashbang
-      "g3sg1" -> :g3sg1
-      "galilar" -> :galilar
-      "glock" -> :glock
-      "hegrenade" -> :hegrenade
-      "hkp2000" -> :hkp2000
-      "incgrenade" -> :incgrenade
-      "inferno" -> :inferno
-      "knife" -> :knife
-      "knife_t" -> :knife_t
-      "m249" -> :m249
-      "m4a1" -> :m4a1
-      "m4a1_silencer" -> :m4a1_silencer
-      "mac10" -> :mac10
-      "mag7" -> :mag7
-      "molotov" -> :molotov
-      "mp7" -> :mp7
-      "mp9" -> :mp9
-      "negev" -> :negev
-      "nova" -> :nova
-      "p250" -> :p250
-      "p90" -> :p90
-      "sawedoff" -> :sawedoff
-      "scar20" -> :scar20
-      "sg556" -> :sg556
-      "smokegrenade" -> :smokegrenade
-      "ssg08" -> :ssg08
-      "taser" -> :taser
-      "tec9" -> :tec9
-      "ump45" -> :ump45
-      "usp_silencer" -> :usp_silencer
-      "xm1014" -> :xm1014
-    end
+    String.to_existing_atom(weapon)
   end
 end

--- a/lib/csgo_stats/matches/match.ex
+++ b/lib/csgo_stats/matches/match.ex
@@ -92,7 +92,7 @@ defmodule CsgoStats.Matches.Match do
     %{
       state
       | phase: :freeze_period,
-        map: event.map,
+        map: event.game_map,
         timeout: timeout,
         timeout_event_time: event.timestamp
     }

--- a/lib/csgo_stats/matches/match.ex
+++ b/lib/csgo_stats/matches/match.ex
@@ -6,7 +6,7 @@ defmodule CsgoStats.Matches.Match do
     :debug,
     :phase,
     :wins,
-    :map,
+    :game_map,
     :players,
     :timeout,
     :timeout_event_time,
@@ -92,7 +92,7 @@ defmodule CsgoStats.Matches.Match do
     %{
       state
       | phase: :freeze_period,
-        map: event.game_map,
+        game_map: event.game_map,
         timeout: timeout,
         timeout_event_time: event.timestamp
     }

--- a/lib/csgo_stats/types.ex
+++ b/lib/csgo_stats/types.ex
@@ -1,0 +1,121 @@
+defmodule CsgoStats.Types do
+  @game_modes [:casual, :competitive]
+  @type game_mode() :: unquote(@game_modes |> Enum.reverse() |> Enum.reduce(&{:|, [], [&1, &2]}))
+  def game_modes(), do: @game_modes
+
+  @teams [:ct, :terrorist, :unassigned, :spectator]
+  @type team() :: unquote(@teams |> Enum.reverse() |> Enum.reduce(&{:|, [], [&1, &2]}))
+  def teams(), do: @teams
+
+  @game_maps [
+    :de_cache,
+    :de_vertigo,
+    :de_dust2,
+    :de_inferno,
+    :de_mirage,
+    :de_nuke,
+    :de_overpass,
+    :de_train
+  ]
+  @type game_map() :: unquote(@game_maps |> Enum.reverse() |> Enum.reduce(&{:|, [], [&1, &2]}))
+  def game_maps(), do: @game_maps
+
+  @win_conditions [
+    :terrorists_win,
+    :cts_win,
+    :target_bombed,
+    :bomb_defused,
+    :target_saved
+  ]
+  @type win_condition() ::
+          unquote(@win_conditions |> Enum.reverse() |> Enum.reduce(&{:|, [], [&1, &2]}))
+  def win_conditions(), do: @win_conditions
+
+  @type player() :: map()
+
+  @pistols [
+    :cz75a,
+    :deagle,
+    :elite,
+    :glock,
+    :hkp2000,
+    :p250,
+    :tec9,
+    :usp_silencer
+  ]
+
+  @guns [
+    :ak47,
+    :aug,
+    :awp,
+    :bizon,
+    :famas,
+    :g3sg1,
+    :galilar,
+    :m249,
+    :m4a1_silencer,
+    :m4a1,
+    :mac10,
+    :mag7,
+    :mp7,
+    :mp9,
+    :negev,
+    :nova,
+    :p90,
+    :sawedoff,
+    :scar20,
+    :sg556,
+    :ssg08,
+    :ump45,
+    :xm1014
+  ]
+
+  @grenades [
+    :decoy,
+    :flashbang,
+    :hegrenade,
+    :incgrenade,
+    :inferno,
+    :molotov,
+    :smokegrenade
+  ]
+  @type grenade() :: unquote(@grenades |> Enum.reverse() |> Enum.reduce(&{:|, [], [&1, &2]}))
+  def grenades(), do: @grenades
+
+  @weapons [:knife_t, :knife, :taser] ++ @pistols ++ @guns ++ @grenades
+  @type weapon() :: unquote(@weapons |> Enum.reverse() |> Enum.reduce(&{:|, [], [&1, &2]}))
+  def weapons(), do: @weapons
+
+  @items [:c4, :defuser, :vest, :vesthelm]
+  @type item() :: unquote(@items |> Enum.reverse() |> Enum.reduce(&{:|, [], [&1, &2]}))
+  def items(), do: @items
+
+  @awards [:"3k", :hsp, :firstkills, :cashspent, :deaths, :mvps, :assists]
+  @type award() :: unquote(@awards |> Enum.reverse() |> Enum.reduce(&{:|, [], [&1, &2]}))
+  def awards() do
+    @awards
+  end
+
+  @hitgroups [
+    :chest,
+    :generic,
+    :head,
+    :left_arm,
+    :left_leg,
+    :neck,
+    :right_arm,
+    :right_leg,
+    :stomach
+  ]
+  @type hitgroup() :: unquote(@hitgroups |> Enum.reverse() |> Enum.reduce(&{:|, [], [&1, &2]}))
+  def hitgroups(), do: @hitgroups
+
+  @killables [:chicken, :func_breakable]
+  @type killable() :: unquote(@killables |> Enum.reverse() |> Enum.reduce(&{:|, [], [&1, &2]}))
+  def killables(), do: @killables
+
+  @disconnect_reasons [:disconnect, :kicked_by_console, :server_shutting_down]
+  @type disconnect_reason() ::
+          unquote(@disconnect_reasons |> Enum.reverse() |> Enum.reduce(&{:|, [], [&1, &2]}))
+  def disconnect_reasons(), do: @disconnect_reasons
+end

--- a/lib/csgo_stats_web/templates/match/show.html.leex
+++ b/lib/csgo_stats_web/templates/match/show.html.leex
@@ -3,7 +3,7 @@
     <div class="key">
       Map
     </div>
-    <div class="value"><%= if @match.map != nil, do: @match.map, else: "Unknown" %></div>
+    <div class="value"><%= if @match.game_map != nil, do: @match.game_map, else: "Unknown" %></div>
   </div>
 
   <div class="round-info">

--- a/test/csgo_stats/logs/parser_test.exs
+++ b/test/csgo_stats/logs/parser_test.exs
@@ -20,7 +20,7 @@ defmodule CsgoStats.Logs.ParserTest do
 
     test "Match start" do
       line = "11/24/2019 - 21:43:39.781 - World triggered \"Match_Start\" on \"de_inferno\""
-      assert {:ok, [%Events.MatchStart{map: :de_inferno}]} = Parser.parse(line)
+      assert {:ok, [%Events.MatchStart{game_map: :de_inferno}]} = Parser.parse(line)
     end
 
     test "Round start" do
@@ -80,7 +80,8 @@ defmodule CsgoStats.Logs.ParserTest do
       line =
         "11/24/2019 - 21:43:39.781 - \"Uri<13><BOT>\" switched from team <Unassigned> to <CT>"
 
-      assert {:ok, [%Events.PlayerSwitchedTeam{player: %{username: "Uri"}, from: nil, to: :ct}]} =
+      assert {:ok,
+              [%Events.PlayerSwitchedTeam{player: %{username: "Uri"}, from: :unassigned, to: :ct}]} =
                Parser.parse(line)
     end
 
@@ -150,7 +151,7 @@ defmodule CsgoStats.Logs.ParserTest do
                   damage_armor: 29,
                   health: 39,
                   armor: 70,
-                  hitgroup: "head"
+                  hitgroup: :head
                 }
               ]} = Parser.parse(line)
 
@@ -163,7 +164,7 @@ defmodule CsgoStats.Logs.ParserTest do
                   attacker: %{username: "Clarence"},
                   attacked: %{username: "Niles"},
                   weapon: :aug,
-                  hitgroup: "left leg"
+                  hitgroup: :left_leg
                 }
               ]} = Parser.parse(left_leg)
     end
@@ -255,7 +256,7 @@ defmodule CsgoStats.Logs.ParserTest do
               [
                 %Events.KilledOther{
                   killer: %{username: "tbroedsgaard"},
-                  killed: "chicken",
+                  killed: :chicken,
                   weapon: :awp,
                   penetrated: false,
                   headshot: false
@@ -269,7 +270,7 @@ defmodule CsgoStats.Logs.ParserTest do
               [
                 %Events.KilledOther{
                   killer: %{username: "tbroedsgaard"},
-                  killed: "chicken",
+                  killed: :chicken,
                   weapon: :awp,
                   penetrated: false,
                   headshot: true
@@ -283,7 +284,7 @@ defmodule CsgoStats.Logs.ParserTest do
               [
                 %Events.KilledOther{
                   killer: %{username: "Yogi"},
-                  killed: "func_breakable",
+                  killed: :func_breakable,
                   weapon: :mp7,
                   penetrated: true,
                   headshot: false
@@ -363,7 +364,7 @@ defmodule CsgoStats.Logs.ParserTest do
                   previous: 3000,
                   diff: -2000,
                   result: 1000,
-                  purchase: "weapon_xm1014"
+                  purchase: :xm1014
                 }
               ]} = Parser.parse(purchase)
     end


### PR DESCRIPTION
This was a small thing I wanted to do that turned out to be a pretty big diff - sorry about that 😄 

The main purpose is to make it easier to figure out what the possible values of fields on events can be - what are the names of the different maps, game modes, weapons, etc. All the possible values for these "constant types" are now defined in `CsgoStats.Types`.

In addition, I also wanted to make the parser be more strict, in order to guarantee that these are in fact the only values that will be parsed out - if it tries to parse a game map or a weapon that is unknown, the parser should skip the event, instead of sending it downstream - in order to avoid missing logic and/or assets for those cases. 

In some cases, re-using the type definitions in the parser makes the parser module a lot smaller - e.g. `CsgoStats.Logs.Parser.Weapon`. This is the case when the strings directly match the atom names. I can simply map over the list of possible atoms for a weapon  and translate them to parser combinators with `NimbleParsec.string/1`. And then I can safely cast the weapon's string name to an atom with `String.to_existing_atom/1` since I know the atom has been defined. Now, to add support for a new weapon type I just have to add the weapon to the list in `CsgoStats.Types` and the parser definition updates automatically. 

When the strings don't match the atom names, the code is a bit more complex 🤢 An example is `CsgoStats.Logs.Parser.Item`. In these cases I use another approach. I still hardcode the parser combinators for strings, but then define translation functions by using the list of possible values defined in `CsgoStats.Types`. When done this way, ElixirLS can generate a warning if my definition is not complete. E.g. if I define the `cast_item` function, but forget a match for `:c4`, I get a compile error like this: 

<img width="790" alt="Screenshot 2020-10-30 at 07 59 15" src="https://user-images.githubusercontent.com/6442970/97670143-e7641300-1a85-11eb-9b92-2ed6a8c9a807.png">

So even though the code is a little unusual, I like the fact that it can help make sure we match all the possible cases.