### PR TITLE
Add archiving of raw logs

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -7,9 +7,9 @@ secret_key_base =
     You can generate one by calling: mix phx.gen.secret
     """
 
-listen_port = String.to_integer(System.get_env("LISTEN_PORT") || "4000")
-url_scheme = System.get_env("URL_SCHEME") || "http"
-url_host = System.get_env("URL_HOST") || "localhost"
+listen_port = String.to_integer(System.get_env("LISTEN_PORT", "4000"))
+url_scheme = System.get_env("URL_SCHEME", "http")
+url_host = System.get_env("URL_HOST", "localhost")
 
 config :csgo_stats, CsgoStatsWeb.Endpoint,
   http: [port: listen_port],
@@ -18,3 +18,5 @@ config :csgo_stats, CsgoStatsWeb.Endpoint,
     host: url_host
   ],
   secret_key_base: secret_key_base
+
+config :csgo_stats, log_dir: System.get_env("LOG_DIR", "/tmp/csgo_stats_logs/")

--- a/lib/csgo_stats/application.ex
+++ b/lib/csgo_stats/application.ex
@@ -5,6 +5,7 @@ defmodule CsgoStats.Application do
 
   def start(_type, _args) do
     CsgoStats.Matches.DB.init()
+    CsgoStats.Logs.init()
 
     children = [
       {Phoenix.PubSub, name: CsgoStats.PubSub},

--- a/lib/csgo_stats/logs.ex
+++ b/lib/csgo_stats/logs.ex
@@ -6,7 +6,8 @@ defmodule CsgoStats.Logs do
 
   def process(data, metadata) do
     with {:ok, entry} <- Entry.new(data, metadata),
-         true <- CsgoStats.Matches.started?(metadata.server_instance_token) do
+         true <- CsgoStats.Matches.started?(entry.server_instance_token) do
+      :ok = log(entry.server_instance_token, data)
       events = do_parse(entry)
       :ok = Matches.update(entry.server_instance_token, events)
     else
@@ -36,5 +37,19 @@ defmodule CsgoStats.Logs do
         Logger.error(["event_error||", entry.lines, "||", unparsed])
         []
     end
+  end
+
+  def init() do
+    File.mkdir_p!(log_dir())
+  end
+
+  defp log_dir() do
+    Application.get_env(:csgo_stats, :log_dir, "/tmp/csgo_stats_logs/")
+  end
+
+  defp log(server_instance_token, data) do
+    log_dir()
+    |> Path.join(server_instance_token)
+    |> File.write(data, [:append])
   end
 end


### PR DESCRIPTION
A very simple addition that just makes sure we archive all received logs. This should be very useful for collecting data for further improvements later on.